### PR TITLE
fix: fix code for empty message

### DIFF
--- a/src/scverse_misc/_deprecated.py
+++ b/src/scverse_misc/_deprecated.py
@@ -28,6 +28,8 @@ class Deprecation(str):
         msg: The deprecation message.
     """
 
+    version_deprecated: LiteralString
+
     def __new__(cls, version_deprecated: LiteralString, msg: LiteralString = "") -> LiteralString:
         obj = super().__new__(cls, msg)
         obj.version_deprecated = version_deprecated
@@ -56,7 +58,7 @@ def _deprecated_at(msg: Deprecation, *, category=FutureWarning, stacklevel=1) ->
 
         doc = getdoc(func)
         docmsg = f".. version-deprecated:: {msg.version_deprecated}"
-        if len(msg) is not None:
+        if len(msg):
             docmsg += f"\n   {msg}"
             warnmsg += f" {msg}"
 

--- a/src/scverse_misc/_deprecated.py
+++ b/src/scverse_misc/_deprecated.py
@@ -31,6 +31,8 @@ class Deprecation(str):
     version_deprecated: LiteralString
 
     def __new__(cls, version_deprecated: LiteralString, msg: LiteralString = "") -> LiteralString:
+        if not msg:
+            msg = ""  # be lenient here, people don’t want to see “None” or “False” here
         obj = super().__new__(cls, msg)
         obj.version_deprecated = version_deprecated
         return obj

--- a/tests/test_deprecation_decorator.py
+++ b/tests/test_deprecation_decorator.py
@@ -50,5 +50,7 @@ def test_deprecation_decorator(deprecated_func, docstring, msg):
         assert lines[0] == lines_orig[0]
         assert len(lines[1].strip()) == 0
         assert lines[2].startswith(".. version-deprecated")
-        if msg is not None:
+        if msg is None:
+            assert len(lines) == 3
+        else:
             assert lines[3] == f"   {msg}"

--- a/tests/test_deprecation_decorator.py
+++ b/tests/test_deprecation_decorator.py
@@ -35,7 +35,7 @@ def deprecated_func(msg, docstring):
         return 42
 
     func.__doc__ = docstring
-    return deprecated(Deprecation("foo", msg))(func)
+    return deprecated(Deprecation("foo", msg or ""))(func)
 
 
 def test_deprecation_decorator(deprecated_func, docstring, msg):

--- a/tests/test_deprecation_decorator.py
+++ b/tests/test_deprecation_decorator.py
@@ -51,6 +51,6 @@ def test_deprecation_decorator(deprecated_func, docstring, msg):
         assert len(lines[1].strip()) == 0
         assert lines[2].startswith(".. version-deprecated")
         if msg is None:
-            assert len(lines) == 3
+            assert len(lines) == 3 or not lines[3].startswith("   ")
         else:
             assert lines[3] == f"   {msg}"


### PR DESCRIPTION
the test code so far generated

```restructuredtext
.. version-deprecated:: foo
   None
```

which is certainly not intended