### PR TITLE
feat: explicit exports

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -55,7 +55,6 @@ doc = [
 ]
 
 [tool.hatch]
-build.hooks.vcs.version-file = "src/scverse_misc/_version.py"
 envs.default.installer = "uv"
 envs.default.dependency-groups = [ "dev" ]
 envs.docs.dependency-groups = [ "doc" ]

--- a/src/scverse_misc/__init__.py
+++ b/src/scverse_misc/__init__.py
@@ -1,3 +1,4 @@
 from ._deprecated import Deprecation, deprecated
 from ._extensions import ExtensionNamespace, make_register_namespace_decorator
-from ._version import __version__, __version_tuple__
+
+__all__ = ["ExtensionNamespace", "make_register_namespace_decorator", "deprecated", "Deprecation"]

--- a/src/scverse_misc/_deprecated.py
+++ b/src/scverse_misc/_deprecated.py
@@ -20,6 +20,9 @@ if TYPE_CHECKING:
     F = TypeVar("F", bound=Callable)
 
 
+__all__ = ["deprecated", "Deprecation"]
+
+
 class Deprecation(str):
     """Utility class storing information on deprecated functionality.
 

--- a/src/scverse_misc/_extensions.py
+++ b/src/scverse_misc/_extensions.py
@@ -9,6 +9,9 @@ if TYPE_CHECKING:
     from collections.abc import Callable, Set
 
 
+__all__ = ["ExtensionNamespace", "make_register_namespace_decorator"]
+
+
 @runtime_checkable
 class ExtensionNamespace(Protocol):
     """Protocol for extension namespaces.


### PR DESCRIPTION
Also get rid of the `__version__` attribute, I really want to discourage people from using that over `importlib.metadata.version`. Versions are properties of distributions (PyPI packages), not import packages, and there is a canonical way in the stdlib to retrieve them using the distribution name. This is often the same, but doing things right makes things way less confusing when it isn’t the same.

Also regarding `__version_tuple__`: If people want a structured version, they can depend on `packaging` and parse the version using `packaging.version.Version`. It’s extremely fast and all our packages import `packaging` anyway at import time.