### PR TITLE
docs: fix some URLs

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -27,7 +27,7 @@ jobs:
         run: uv build
       - id: wheel
         run: |
-          version="$(uvx wheel-filename dist/*.whl | jq .version)"
+          version="$(uvx wheel-filename dist/*.whl | jq -r .version)"
           echo "version=$version" >> "$GITHUB_OUTPUT"
       - name: Publish package distributions to PyPI
         uses: pypa/gh-action-pypi-publish@release/v1

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -13,11 +13,11 @@ jobs:
     runs-on: ubuntu-latest
     environment:
       name: pypi
-      url: https://pypi.org/p/mofaflex
+      url: https://pypi.org/p/scverse-misc/${{ steps.wheel.outputs.version }}/
     permissions:
       id-token: write # IMPORTANT: this permission is mandatory for trusted publishing
     steps:
-      - uses: actions/checkout@v5
+      - uses: actions/checkout@v6
         with:
           filter: blob:none
           fetch-depth: 0
@@ -25,5 +25,9 @@ jobs:
         uses: astral-sh/setup-uv@v7
       - name: Build package
         run: uv build
+      - id: wheel
+        run: |
+          version="$(uvx wheel-filename dist/*.whl | jq .version)"
+          echo "version=$version" >> "$GITHUB_OUTPUT"
       - name: Publish package distributions to PyPI
         uses: pypa/gh-action-pypi-publish@release/v1

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -13,7 +13,7 @@ jobs:
     runs-on: ubuntu-latest
     environment:
       name: pypi
-      url: https://pypi.org/p/scverse-misc/${{ steps.wheel.outputs.version }}/
+      url: https://pypi.org/project/scverse-misc/${{ steps.wheel.outputs.version }}/
     permissions:
       id-token: write # IMPORTANT: this permission is mandatory for trusted publishing
     steps:

--- a/README.md
+++ b/README.md
@@ -24,13 +24,13 @@ If you don't have Python installed, we recommend installing [uv][].
 
 There are several alternative options to install scverse-misc:
 
-1) Install the latest release of `scverse-misc` from [PyPI][]:
+1. Install the latest release of `scverse-misc` from [PyPI][]:
 
 ```bash
 pip install scverse-misc
 ```
 
-1. Install the latest development version:
+2. Install the latest development version:
 
 ```bash
 pip install git+https://github.com/scverse/scverse-misc.git@main

--- a/README.md
+++ b/README.md
@@ -24,13 +24,11 @@ If you don't have Python installed, we recommend installing [uv][].
 
 There are several alternative options to install scverse-misc:
 
-<!--
 1) Install the latest release of `scverse-misc` from [PyPI][]:
 
 ```bash
 pip install scverse-misc
 ```
--->
 
 1. Install the latest development version:
 
@@ -54,6 +52,6 @@ If you found a bug, please use the [issue tracker][].
 [tests]: https://github.com/scverse/scverse-misc/actions/workflows/test.yaml
 [codecov]: https://codecov.io/gh/scverse/scverse-misc
 [documentation]: https://scverse-misc.readthedocs.io
-[changelog]: https://scverse-misc.readthedocs.io/en/latest/changelog.html
-[api documentation]: https://scverse-misc.readthedocs.io/latest/api.html
+[changelog]: https://scverse-misc.readthedocs.io/page/changelog.html
+[api documentation]: https://scverse-misc.readthedocs.io/page/api.html
 [pypi]: https://pypi.org/project/scverse-misc


### PR DESCRIPTION
In case you didn’t know: the `page` redirect will always point to the default version be correct, whereas changes to the scheme `en/latest` -> `latest` break direct URLs.