### PR TITLE
fix: add module to annotation types

### DIFF
--- a/src/scverse_misc/_settings.py
+++ b/src/scverse_misc/_settings.py
@@ -14,12 +14,12 @@ from pydantic_settings import BaseSettings, PydanticBaseSettingsSource, Settings
 from ._utils import copy_func
 
 
-def _type_str(field: FieldInfo) -> str:
-    return (
-        field.annotation.__name__  # f"{field.annotation.__module__}.{field.annotation.__qualname__}"
-        if isinstance(field.annotation, type) and not isinstance(field.annotation, GenericAlias)
-        else str(field.annotation)
-    )
+def _type_str(cls: type, field: FieldInfo) -> str:
+    if isinstance(field.annotation, GenericAlias) or not isinstance(field.annotation, type):
+        return str(field.annotation)
+    if cls.__module__ == field.annotation.__module__:
+        return field.annotation.__qualname__
+    return f"{field.annotation.__module__}.{field.annotation.__qualname__}"
 
 
 _docstring_template = """Allows users to customize settings for the `{package}` package.
@@ -143,7 +143,7 @@ class Settings(BaseSettings):
         for fname, field in subcls.model_fields.items():
             subcls.__doc__ += f"""
 .. attribute:: {exported_object_name}.{fname}
-   :type: {_type_str(field)}
+   :type: {_type_str(subcls, field)}
    :value: {field.default!r}\n"""
 
             description = f"(default `{field.default!r}`) "
@@ -152,10 +152,12 @@ class Settings(BaseSettings):
                 description += field.description
 
             if docstring_style == "google":
-                override_doc += f"""    {fname} ({_type_str(field)}): {textwrap.indent(description, "        ")}\n"""
+                override_doc += (
+                    f"""    {fname} ({_type_str(subcls, field)}): {textwrap.indent(description, "        ")}\n"""
+                )
             else:
                 override_doc += f"""
-{fname} : {_type_str(field)}
+{fname} : {_type_str(subcls, field)}
 {textwrap.indent(description, "    ")}\n"""
 
         subcls.override = copy_func(  # type: ignore[method-assign,type-var]

--- a/src/scverse_misc/_settings.py
+++ b/src/scverse_misc/_settings.py
@@ -16,7 +16,7 @@ from ._utils import copy_func
 
 def _type_str(field: FieldInfo) -> str:
     return (
-        field.annotation.__name__
+        field.annotation.__name__  # f"{field.annotation.__module__}.{field.annotation.__qualname__}"
         if isinstance(field.annotation, type) and not isinstance(field.annotation, GenericAlias)
         else str(field.annotation)
     )

--- a/src/scverse_misc/_settings.py
+++ b/src/scverse_misc/_settings.py
@@ -17,7 +17,7 @@ from ._utils import copy_func
 def _type_str(cls: type, field: FieldInfo) -> str:
     if isinstance(field.annotation, GenericAlias) or not isinstance(field.annotation, type):
         return str(field.annotation)
-    if cls.__module__ == field.annotation.__module__:
+    if field.annotation.__module__ in {"builtins", cls.__module__}:
         return field.annotation.__qualname__
     return f"{field.annotation.__module__}.{field.annotation.__qualname__}"
 

--- a/tests/test_settings.py
+++ b/tests/test_settings.py
@@ -136,19 +136,19 @@ def test_override_docs(docstring_style: Literal["google", "numpy"], settings: Du
         pytest.param("string", "str", id="builtin"),
         pytest.param("path", "pathlib.Path", id="3rd-party"),
         # same module as `S`, so no leading `tests.test_settings.`
-        pytest.param("t", "test_annotation_format.<locals>.T", id="same-module"),
+        pytest.param("local", "test_annotation_format.<locals>.Local", id="same-module"),
     ],
 )
 def test_annotation_format(attr: str, expected: str) -> None:
     """Test that annotation references work correctly."""
     from pathlib import Path
 
-    class T: ...
+    class Local: ...
 
     class S(Settings, exported_object_name="s"):
         string: str
         path: Path
-        t: T
+        local: Local
 
     line_iter = iter((inspect.getdoc(S) or "").splitlines())
     for line in line_iter:

--- a/tests/test_settings.py
+++ b/tests/test_settings.py
@@ -127,3 +127,15 @@ def test_override_docs(docstring_style: Literal["google", "numpy"], settings: Du
             assert line.startswith(f":param {current_field_name}: (default `{current_field.default!r}`){description}")
         elif current_field is not None and len(line) > 0:
             assert line == f":type {current_field_name}: {current_field.annotation.__name__}"  # type: ignore[union-attr]
+
+
+def test_annotation_format() -> None:
+    from pathlib import Path
+
+    class S(Settings, exported_object_name="s"):
+        path: Path
+
+    docstring = inspect.getdoc(S)
+    type_str = next(l.strip().removeprefix(":type:") for l in docstring.splitlines() if ":type" in l)
+
+    assert type_str == "pathlib.Path"

--- a/tests/test_settings.py
+++ b/tests/test_settings.py
@@ -130,13 +130,30 @@ def test_override_docs(docstring_style: Literal["google", "numpy"], settings: Du
             assert line == f":type {current_field_name}: {current_field.annotation.__name__}"
 
 
-def test_annotation_format() -> None:
+@pytest.mark.parametrize(
+    ("attr", "expected"),
+    [
+        pytest.param("path", "pathlib.Path", id="3rd-party"),
+        # same module as `S`, so no leading `tests.test_settings.`
+        pytest.param("t", "test_annotation_format.<locals>.T", id="same-module"),
+    ],
+)
+def test_annotation_format(attr: str, expected: str) -> None:
+    """Test that annotation references work correctly."""
     from pathlib import Path
+
+    class T: ...
 
     class S(Settings, exported_object_name="s"):
         path: Path
+        t: T
 
-    docstring = inspect.getdoc(S)
-    type_str = next(l.strip().removeprefix(":type:") for l in docstring.splitlines() if ":type" in l)
+    line_iter = iter((inspect.getdoc(S) or "").splitlines())
+    for line in line_iter:
+        if line == f".. attribute:: s.{attr}":
+            type_str = next(line_iter).strip().removeprefix(":type: ")
+            break
+    else:
+        raise AssertionError(f"Annotation for {attr} not found")
 
-    assert type_str == "pathlib.Path"
+    assert type_str == expected

--- a/tests/test_settings.py
+++ b/tests/test_settings.py
@@ -133,6 +133,7 @@ def test_override_docs(docstring_style: Literal["google", "numpy"], settings: Du
 @pytest.mark.parametrize(
     ("attr", "expected"),
     [
+        pytest.param("string", "str", id="builtin"),
         pytest.param("path", "pathlib.Path", id="3rd-party"),
         # same module as `S`, so no leading `tests.test_settings.`
         pytest.param("t", "test_annotation_format.<locals>.T", id="same-module"),
@@ -145,6 +146,7 @@ def test_annotation_format(attr: str, expected: str) -> None:
     class T: ...
 
     class S(Settings, exported_object_name="s"):
+        string: str
         path: Path
         t: T
 


### PR DESCRIPTION
Trying to use the settings class for scanpy, I got

> `~/Dev/Python/scanpy/src/scanpy/__init__.py:docstring of scanpy.settings:79:` WARNING: py:class reference target not found: Path [ref.class]

this should fix that.