### PR TITLE
feat!: add annotations

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -45,4 +45,5 @@ repos:
       - pydantic-settings
       - pytest
       - sphinx
+      - sphinx-autodoc-typehints
       - sphinxcontrib-katex

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,7 +21,7 @@ and this project adheres to [Semantic Versioning][].
 ### Fixed
 
 - The `Settings` docstrings longer have `:value: PydanticUndefined` for fields with no defaults.
-- Remove the “default” text from `override` parameters so we don’t imply that `override` resets all settings the user isn’t overriding
+- Remove the “default” text from `override` parameters so we don’t imply that `override` resets all settings the user isn’t overriding.
 
 ## [0.0.4]
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,10 +10,17 @@ and this project adheres to [Semantic Versioning][].
 
 ## [0.0.5]
 
+### Added
+
+- The `docstring_style` used by scanpy, `"scverse"`, which looks like `"numpy"` but with no parameter types in the docstring.
+
 ### Changed
 
 - The `Settings` class now requires passing a `docstring_style` argument.
-- The `docstring_style` used by scanpy, `"scverse"`, has been added.
+
+### Fixed
+
+- The `Settings` docstrings longer have `:value: PydanticUndefined` for fields with no defaults.
 
 ## [0.0.4]
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,9 +8,16 @@ and this project adheres to [Semantic Versioning][].
 [keep a changelog]: https://keepachangelog.com/en/1.1.0/
 [semantic versioning]: https://semver.org/spec/v2.0.0.html
 
+## [0.0.5]
+
+### Changed
+
+- The `Settings` class now requires passing a `docstring_style` argument.
+- The `docstring_style` used by scanpy, `"scverse"`, has been added.
+
 ## [0.0.4]
 
-## Added
+### Added
 
 - A `Settings` base class that packages can inherit from for their settings. This is based
   on [Pydantic Settings](https://pydantic.dev/docs/validation/latest/concepts/pydantic_settings/) and
@@ -19,14 +26,14 @@ and this project adheres to [Semantic Versioning][].
 
 ## [0.0.3]
 
-## Added
+### Added
 
 - A `deprecated` decorator wrapping `warnings.deprecated` that additionally modifies the
   docstring to include a deprecation notice.
 
 ## [0.0.2]
 
-## Removed
+### Removed
 
 - The Pandas utility functions
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,7 @@ and this project adheres to [Semantic Versioning][].
 ### Fixed
 
 - The `Settings` docstrings longer have `:value: PydanticUndefined` for fields with no defaults.
+- Remove the “default” text from `override` parameters so we don’t imply that `override` resets all settings the user isn’t overriding
 
 ## [0.0.4]
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,7 +16,7 @@ and this project adheres to [Semantic Versioning][].
 
 ### Changed
 
-- The `Settings` class now requires passing a `docstring_style` argument.
+- The `Settings` class and the `make_register_namespace_decorator` function now require passing a `docstring_style` argument.
 
 ### Fixed
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -37,7 +37,7 @@ dev = [
   "pre-commit",
   "twine>=4.0.2",
 ]
-test = [ "coverage>=7.10", "numpy", "pytest", "scverse-misc[settings]", "sphinx" ]
+test = [ "coverage>=7.10", "numpy", "pytest", "scverse-misc[settings]", "sphinx", "sphinx-autodoc-typehints" ]
 doc = [
   "ipykernel",
   "ipython",

--- a/src/scverse_misc/_extensions.py
+++ b/src/scverse_misc/_extensions.py
@@ -164,11 +164,7 @@ def _indent_string_lines(string: str, indentation_level: int, skip_lines: int = 
 
 
 def make_register_namespace_decorator[NameSpT: ExtensionNamespace](
-    cls: type,
-    canonical_instance_name: str,
-    decorator_name: str,
-    *,
-    docstring_style: Literal["google", "numpy", "scverse"],
+    cls: type, canonical_instance_name: str, decorator_name: str, docstring_style: Literal["google", "numpy", "scverse"]
 ) -> Callable[[str], Callable[[type[NameSpT]], type[NameSpT]]]:
     """Create a decorator for registering custom functionality with a class.
 

--- a/src/scverse_misc/_extensions.py
+++ b/src/scverse_misc/_extensions.py
@@ -164,7 +164,11 @@ def _indent_string_lines(string: str, indentation_level: int, skip_lines: int = 
 
 
 def make_register_namespace_decorator[NameSpT: ExtensionNamespace](
-    cls: type, canonical_instance_name: str, decorator_name: str, docstring_style: Literal["google", "numpy"] = "google"
+    cls: type,
+    canonical_instance_name: str,
+    decorator_name: str,
+    *,
+    docstring_style: Literal["google", "numpy", "scverse"],
 ) -> Callable[[str], Callable[[type[NameSpT]], type[NameSpT]]]:
     """Create a decorator for registering custom functionality with a class.
 
@@ -181,8 +185,9 @@ def make_register_namespace_decorator[NameSpT: ExtensionNamespace](
             is used for run-time checking of constructor signatures of the namespace classes.
         decorator_name: The name under which the decorator is accessible in your package. This is used for
             the examples in the decorator docstring.
-        docstring_style: Whether the docstring of the generated decorator should conform to NumPy or Google
-            style.
+        docstring_style: Whether the docstring of the generated decorator should conform to `"numpy"` or
+            `"google"` style. We also support variant of `"numpy"` called `"scverse"`,
+            which does not duplicate type annotation in docstrings.
     """
     # Reserved namespaces include accessors built into cls and all current attributes of cls
     reserved_namespaces = set(dir(cls))

--- a/src/scverse_misc/_settings.py
+++ b/src/scverse_misc/_settings.py
@@ -147,10 +147,10 @@ class Settings(BaseSettings):
             subcls.__doc__ += f"""
 .. attribute:: {exported_object_name}.{fname}
    :type: {_type_str(subcls, field)}\n"""
-            description = ""
             if field.default is not PydanticUndefined:
                 subcls.__doc__ += f"   :value: {field.default!r}\n"
 
+            description = ""
             if field.description is not None:
                 subcls.__doc__ += f"\n{textwrap.indent(field.description, '   ')}\n"
                 description += field.description
@@ -199,6 +199,8 @@ def _copy_override[F: FunctionType](cls: type[Settings], func: F, doc: str, retu
     )
     if sys.version_info >= (3, 14):
         str_annotations = {n: _type_str(cls, f) for n, f in cls.model_fields.items()}
+        # All formats can be real values except for STRING:
+        # see https://docs.python.org/3/library/annotationlib.html#annotationlib.Format
         overrides["__annotate__"] = lambda fmt: overrides["__annotations__"] if fmt != 4 else str_annotations
 
     return copy_func(func, **overrides)

--- a/src/scverse_misc/_settings.py
+++ b/src/scverse_misc/_settings.py
@@ -198,9 +198,11 @@ def _copy_override[F: FunctionType](cls: type[Settings], func: F, doc: str, retu
         },
     )
     if sys.version_info >= (3, 14):
+        from annotationlib import Format
+
         str_annotations = {n: _type_str(cls, f) for n, f in cls.model_fields.items()}
-        # All formats can be real values except for STRING:
-        # see https://docs.python.org/3/library/annotationlib.html#annotationlib.Format
-        overrides["__annotate__"] = lambda fmt: overrides["__annotations__"] if fmt != 4 else str_annotations
+        overrides["__annotate__"] = lambda fmt: (
+            overrides["__annotations__"] if fmt != Format.STRING else str_annotations
+        )
 
     return copy_func(func, **overrides)

--- a/src/scverse_misc/_settings.py
+++ b/src/scverse_misc/_settings.py
@@ -1,18 +1,17 @@
 from __future__ import annotations
 
+import inspect
 import sys
 import textwrap
 import warnings
 from collections.abc import Generator
-from contextlib import contextmanager
-from types import GenericAlias
+from contextlib import AbstractContextManager, contextmanager
+from types import FunctionType, GenericAlias
 from typing import Literal, Self
 
 import dotenv
 from pydantic.fields import FieldInfo
 from pydantic_settings import BaseSettings, PydanticBaseSettingsSource, SettingsConfigDict
-
-from ._utils import Overrides, copy_func
 
 
 def _type_str(field: FieldInfo) -> str:
@@ -160,17 +159,33 @@ class Settings(BaseSettings):
 {fname}{annot}
 {textwrap.indent(description, "    ")}\n"""
 
-        annotations = {name: field.annotation for name, field in subcls.model_fields.items()}
-        kw = Overrides(
-            __doc__=override_doc, __module__=subcls.__module__, __qualname__=f"{subcls.__qualname__}.override"
+        subcls.override = _copy_override(  # type: ignore[method-assign,type-var]
+            subcls, subcls.override, override_doc, return_annotation=AbstractContextManager[None]
         )
-        if sys.version_info >= (3, 14):
-            kw["__annotate__"] = lambda fmt: (
-                annotations if fmt != 4 else {n: _type_str(a) for n, a in annotations.items()}
-            )
-        else:
-            kw["__annotations__"] = annotations
 
-        subcls.override = copy_func(  # type: ignore[method-assign,type-var]
-            subcls.override, **kw
-        )
+
+def _copy_override[F: FunctionType](cls: type[Settings], func: F, doc: str, return_annotation: object) -> F:
+    from ._utils import Overrides, copy_func
+
+    parameters = [
+        inspect.Parameter("self", inspect.Parameter.POSITIONAL_ONLY),
+        *[
+            inspect.Parameter(n, inspect.Parameter.KEYWORD_ONLY, default=f.default, annotation=f.annotation)
+            for n, f in cls.model_fields.items()
+        ],
+    ]
+    overrides = Overrides(
+        __doc__=doc,
+        __module__=cls.__module__,
+        __qualname__=f"{cls.__qualname__}.{func.__name__}",
+        __signature__=inspect.Signature(parameters, return_annotation=return_annotation),
+        __annotations__={
+            **{name: field.annotation for name, field in cls.model_fields.items()},
+            "return": return_annotation,
+        },
+    )
+    if sys.version_info >= (3, 14):
+        str_annotations = {n: _type_str(f) for n, f in cls.model_fields.items()}
+        overrides["__annotate__"] = lambda fmt: overrides["__annotations__"] if fmt != 4 else str_annotations
+
+    return copy_func(func, **overrides)

--- a/src/scverse_misc/_settings.py
+++ b/src/scverse_misc/_settings.py
@@ -147,11 +147,9 @@ class Settings(BaseSettings):
             subcls.__doc__ += f"""
 .. attribute:: {exported_object_name}.{fname}
    :type: {_type_str(subcls, field)}\n"""
-            if field.default is PydanticUndefined:
-                description = ""
-            else:
+            description = ""
+            if field.default is not PydanticUndefined:
                 subcls.__doc__ += f"   :value: {field.default!r}\n"
-                description = "" if docstring_style == "scverse" else f"(default `{field.default!r}`) "
 
             if field.description is not None:
                 subcls.__doc__ += f"\n{textwrap.indent(field.description, '   ')}\n"
@@ -172,13 +170,20 @@ class Settings(BaseSettings):
         )
 
 
+class CustomRepr(str):
+    def __repr__(self) -> str:
+        return self
+
+
 def _copy_override[F: FunctionType](cls: type[Settings], func: F, doc: str, return_annotation: object) -> F:
     from ._utils import Overrides
 
     parameters = [
         inspect.Parameter("self", inspect.Parameter.POSITIONAL_ONLY),
         *[
-            inspect.Parameter(n, inspect.Parameter.KEYWORD_ONLY, default=f.default, annotation=f.annotation)
+            inspect.Parameter(
+                n, inspect.Parameter.KEYWORD_ONLY, default=CustomRepr("<no change>"), annotation=f.annotation
+            )
             for n, f in cls.model_fields.items()
         ],
     ]

--- a/src/scverse_misc/_settings.py
+++ b/src/scverse_misc/_settings.py
@@ -151,7 +151,7 @@ class Settings(BaseSettings):
                 description = ""
             else:
                 subcls.__doc__ += f"   :value: {field.default!r}\n"
-                description = f"(default `{field.default!r}`) "
+                description = "" if docstring_style == "scverse" else f"(default `{field.default!r}`) "
 
             if field.description is not None:
                 subcls.__doc__ += f"\n{textwrap.indent(field.description, '   ')}\n"
@@ -163,7 +163,7 @@ class Settings(BaseSettings):
                 )
             else:
                 annot = "" if docstring_style == "scverse" else f" : {_type_str(subcls, field)}"
-                override_doc += f"""
+                override_doc += f"""\
 {fname}{annot}
 {textwrap.indent(description, "    ")}\n"""
 

--- a/src/scverse_misc/_settings.py
+++ b/src/scverse_misc/_settings.py
@@ -37,9 +37,9 @@ class Settings(BaseSettings):
     '''Base class for package settings.
 
     This class can be subclassed by individual packages to get package-specific settings handling.
-    Settings will be validated on assignment thanks to Pydantic. The class requires one argument
-    `exported_object_name` and one optional argument `docstring_style`, which will be used to construct
-    a suitable docstring (see the examples).
+    Settings will be validated on assignment thanks to Pydantic. The class requires the arguments
+    `exported_object_name` and `docstring_style`, which will be used to construct a suitable
+    docstring (see the examples).
 
     Both a settings instance and its `override` method should be added to the package documentation.
 
@@ -84,7 +84,7 @@ class Settings(BaseSettings):
             package_name = package_name[:dotidx]
         return package_name
 
-    def __init_subclass__(subcls, *, exported_object_name: str, docstring_style: Literal["google", "numpy"] = "google"):
+    def __init_subclass__(subcls, *, exported_object_name: str, docstring_style: Literal["google", "numpy", "scverse"]):
         if (config := subcls.__dict__.get("model_config")) is not None:
             if not config.get("validate_assignment", True):
                 warnings.warn("`validate_assignment=False` is not supported, overriding.", RuntimeWarning, stacklevel=2)

--- a/src/scverse_misc/_settings.py
+++ b/src/scverse_misc/_settings.py
@@ -11,6 +11,7 @@ from typing import Literal, Self
 
 import dotenv
 from pydantic.fields import FieldInfo
+from pydantic_core import PydanticUndefined
 from pydantic_settings import BaseSettings, PydanticBaseSettingsSource, SettingsConfigDict
 
 from ._utils import copy_func
@@ -145,10 +146,13 @@ class Settings(BaseSettings):
         for fname, field in subcls.model_fields.items():
             subcls.__doc__ += f"""
 .. attribute:: {exported_object_name}.{fname}
-   :type: {_type_str(subcls, field)}
-   :value: {field.default!r}\n"""
+   :type: {_type_str(subcls, field)}\n"""
+            if field.default is PydanticUndefined:
+                description = ""
+            else:
+                subcls.__doc__ += f"   :value: {field.default!r}\n"
+                description = f"(default `{field.default!r}`) "
 
-            description = f"(default `{field.default!r}`) "
             if field.description is not None:
                 subcls.__doc__ += f"\n{textwrap.indent(field.description, '   ')}\n"
                 description += field.description
@@ -189,7 +193,7 @@ def _copy_override[F: FunctionType](cls: type[Settings], func: F, doc: str, retu
         },
     )
     if sys.version_info >= (3, 14):
-        str_annotations = {n: _type_str(f) for n, f in cls.model_fields.items()}
+        str_annotations = {n: _type_str(cls, f) for n, f in cls.model_fields.items()}
         overrides["__annotate__"] = lambda fmt: overrides["__annotations__"] if fmt != 4 else str_annotations
 
     return copy_func(func, **overrides)

--- a/src/scverse_misc/_settings.py
+++ b/src/scverse_misc/_settings.py
@@ -1,17 +1,18 @@
 from __future__ import annotations
 
+import sys
 import textwrap
 import warnings
 from collections.abc import Generator
 from contextlib import contextmanager
 from types import GenericAlias
-from typing import Literal
+from typing import Literal, Self
 
 import dotenv
 from pydantic.fields import FieldInfo
 from pydantic_settings import BaseSettings, PydanticBaseSettingsSource, SettingsConfigDict
 
-from ._utils import copy_func
+from ._utils import Overrides, copy_func
 
 
 def _type_str(field: FieldInfo) -> str:
@@ -125,7 +126,7 @@ class Settings(BaseSettings):
 
     @classmethod
     def __pydantic_init_subclass__(  # type: ignore[override]
-        subcls, *, exported_object_name: str, docstring_style: Literal["google", "numpy"] = "google"
+        subcls: type[Self], *, exported_object_name: str, docstring_style: Literal["google", "numpy", "scverse"]
     ) -> None:
         subcls.__doc__ = (
             _docstring_template.format(
@@ -154,13 +155,22 @@ class Settings(BaseSettings):
             if docstring_style == "google":
                 override_doc += f"""    {fname} ({_type_str(field)}): {textwrap.indent(description, "        ")}\n"""
             else:
+                annot = "" if docstring_style == "scverse" else f" : {_type_str(field)}"
                 override_doc += f"""
-{fname} : {_type_str(field)}
+{fname}{annot}
 {textwrap.indent(description, "    ")}\n"""
 
+        annotations = {name: field.annotation for name, field in subcls.model_fields.items()}
+        kw = Overrides(
+            __doc__=override_doc, __module__=subcls.__module__, __qualname__=f"{subcls.__qualname__}.override"
+        )
+        if sys.version_info >= (3, 14):
+            kw["__annotate__"] = lambda fmt: (
+                annotations if fmt != 4 else {n: _type_str(a) for n, a in annotations.items()}
+            )
+        else:
+            kw["__annotations__"] = annotations
+
         subcls.override = copy_func(  # type: ignore[method-assign,type-var]
-            subcls.override,
-            __doc__=override_doc,
-            __module__=subcls.__module__,
-            __qualname__=f"{subcls.__qualname__}.override",
+            subcls.override, **kw
         )

--- a/src/scverse_misc/_utils.py
+++ b/src/scverse_misc/_utils.py
@@ -1,4 +1,5 @@
 import functools
+import inspect
 import sys
 from collections.abc import Callable, Mapping
 from functools import WRAPPER_ASSIGNMENTS
@@ -11,6 +12,8 @@ class _BaseOverrides(TypedDict, total=False):
     __name__: str
     __qualname__: str
     __doc__: str
+    __signature__: inspect.Signature
+    __annotations__: Mapping[str, object]
     __type_params__: tuple[TypeVar | TypeVarTuple | ParamSpec, ...]
 
 
@@ -22,7 +25,7 @@ if sys.version_info >= (3, 14):
 else:
 
     class Overrides(_BaseOverrides, total=False):
-        __annotations__: Mapping[str, object]
+        pass
 
 
 def copy_func[F: FunctionType](func: F, /, **overrides: Unpack[Overrides]) -> F:
@@ -33,4 +36,6 @@ def copy_func[F: FunctionType](func: F, /, **overrides: Unpack[Overrides]) -> F:
     for key, value in overrides.items():
         setattr(new, key, value)
     copy = set(WRAPPER_ASSIGNMENTS) - overrides.keys()
-    return cast("F", functools.update_wrapper(new, func, assigned=copy))
+    wrapper = functools.update_wrapper(new, func, assigned=copy)
+    del wrapper.__wrapped__  # otherwise sphinx will try to document that.
+    return cast("F", wrapper)

--- a/src/scverse_misc/_utils.py
+++ b/src/scverse_misc/_utils.py
@@ -1,17 +1,28 @@
 import functools
 import sys
+from collections.abc import Callable, Mapping
 from functools import WRAPPER_ASSIGNMENTS
 from types import FunctionType
 from typing import ParamSpec, TypedDict, TypeVar, TypeVarTuple, Unpack, cast
 
 
-class Overrides(TypedDict, total=False):
+class _BaseOverrides(TypedDict, total=False):
     __module__: str
     __name__: str
     __qualname__: str
     __doc__: str
-    # ≥3.14: __annotate__, <3.14: __annotations__
     __type_params__: tuple[TypeVar | TypeVarTuple | ParamSpec, ...]
+
+
+if sys.version_info >= (3, 14):
+    from annotationlib import Format
+
+    class Overrides(_BaseOverrides, total=False):
+        __annotate__: Callable[[Format], Mapping[str, object]]
+else:
+
+    class Overrides(_BaseOverrides, total=False):
+        __annotations__: Mapping[str, object]
 
 
 def copy_func[F: FunctionType](func: F, /, **overrides: Unpack[Overrides]) -> F:

--- a/tests/test_extensions.py
+++ b/tests/test_extensions.py
@@ -27,7 +27,9 @@ class DummyClass:
     dummy: Greeter  # available when using `dummy_namespace` fixture
 
 
-register_dummy_namespace = make_register_namespace_decorator(DummyClass, "obj", "register_dummy_namespace")
+register_dummy_namespace = make_register_namespace_decorator(
+    DummyClass, "obj", "register_dummy_namespace", docstring_style="google"
+)
 
 
 @pytest.fixture

--- a/tests/test_settings.py
+++ b/tests/test_settings.py
@@ -20,12 +20,12 @@ if TYPE_CHECKING:
 
 
 @pytest.fixture
-def docstring_style(request: pytest.FixtureRequest) -> Literal["google", "numpy"]:
+def docstring_style(request: pytest.FixtureRequest) -> Literal["google", "numpy", "scverse"]:
     return getattr(request, "param", "google")
 
 
 @pytest.fixture
-def settings_class(docstring_style: Literal["google", "numpy"]) -> type[DummySettings]:
+def settings_class(docstring_style: Literal["google", "numpy", "scverse"]) -> type[DummySettings]:
     class _DummySettings(Settings, exported_object_name="settings", docstring_style=docstring_style):
         field_bool: bool = False
         """Boolean field."""
@@ -89,7 +89,7 @@ def test_override(settings: DummySettings) -> None:
     assert settings.field_int_range == 1
 
 
-@pytest.mark.parametrize("docstring_style", ["google", "numpy"], indirect=True)
+@pytest.mark.parametrize("docstring_style", ["google", "numpy", "scverse"], indirect=True)
 def test_docs(docstring_style: Literal["google", "numpy"], settings: DummySettings) -> None:
     parser = GoogleDocstring if docstring_style == "google" else NumpyDocstring
     lines = parser(inspect.getdoc(settings) or "").lines()
@@ -113,7 +113,7 @@ def test_docs(docstring_style: Literal["google", "numpy"], settings: DummySettin
                 assert line == current_field.description
 
 
-@pytest.mark.parametrize("docstring_style", ["google", "numpy"], indirect=True)
+@pytest.mark.parametrize("docstring_style", ["google", "numpy", "scverse"], indirect=True)
 def test_override_docs(docstring_style: Literal["google", "numpy"], settings: DummySettings) -> None:
     parser = GoogleDocstring if docstring_style == "google" else NumpyDocstring
     lines = parser(inspect.getdoc(settings.override) or "").lines()

--- a/tests/test_settings.py
+++ b/tests/test_settings.py
@@ -184,12 +184,12 @@ def test_sphinx_autodoc_typehints(
     settings: DummySettings,
     parent: Literal["class", "object"],
 ) -> None:
-    import sphinx.ext.napoleon
     import sphinx_autodoc_typehints
+    from sphinx.ext.napoleon import NumpyDocstring  # type: ignore[attr-defined]
 
     obj = (settings if parent == "object" else settings_class).override
     lines = (inspect.getdoc(obj) or "").splitlines()
-    lines = sphinx.ext.napoleon.NumpyDocstring(lines, app.config, app, "method", "", obj).lines()
+    lines = NumpyDocstring(lines, app.config, app, "method", "", obj).lines()
 
     with subtests.test("napoleon"):
         # test that napoleon can parse things correctly

--- a/tests/test_settings.py
+++ b/tests/test_settings.py
@@ -1,12 +1,14 @@
 from __future__ import annotations
 
 import inspect
+from pathlib import Path
 from typing import TYPE_CHECKING, Annotated, Literal, cast
 
 import pytest
 from pydantic import Field, ValidationError
 from pydantic.fields import FieldInfo
 from pydantic_settings import SettingsConfigDict
+from sphinx.application import Sphinx
 from sphinx.ext.napoleon import GoogleDocstring, NumpyDocstring  # type: ignore[attr-defined]
 
 from scverse_misc import Settings
@@ -17,6 +19,9 @@ if TYPE_CHECKING:
         field_bool: bool = False
         field_no_docstring: int = 42
         field_int_range: int = 1
+
+
+pytest_plugins = ["sphinx.testing.fixtures"]
 
 
 @pytest.fixture
@@ -141,7 +146,6 @@ def test_override_docs(docstring_style: Literal["google", "numpy"], settings: Du
 )
 def test_annotation_format(attr: str, expected: str) -> None:
     """Test that annotation references work correctly."""
-    from pathlib import Path
 
     class Local: ...
 
@@ -157,3 +161,47 @@ def test_annotation_format(attr: str, expected: str) -> None:
     lines = lines[lines.index(f".. attribute:: s.{attr}") + 1 :]
 
     assert lines == [f"   :type: {expected}"]
+
+
+@pytest.fixture(scope="session", autouse=True)
+def _sphinx_config(sphinx_test_tempdir: Path) -> None:
+    """Since we only need one, we use this instead of static roots like `@pytest.mark.sphinx('html', testroot="mybook")`."""
+    p = sphinx_test_tempdir / "root" / "conf.py"
+    p.parent.mkdir(parents=True)
+    p.write_text("""
+extensions = ["sphinx.ext.autodoc", "sphinx.ext.napoleon", "sphinx_autodoc_typehints"]
+typehints_defaults = "braces"
+""")
+
+
+@pytest.mark.parametrize("docstring_style", ["scverse"])
+@pytest.mark.parametrize("parent", ["class", "object"])
+def test_sphinx_autodoc_typehints(
+    subtests: pytest.Subtests,
+    app: Sphinx,
+    settings_class: type[DummySettings],
+    settings: DummySettings,
+    parent: Literal["class", "object"],
+) -> None:
+    import sphinx.ext.napoleon
+    import sphinx_autodoc_typehints
+
+    obj = (settings if parent == "object" else settings_class).override
+    lines = (inspect.getdoc(obj) or "").splitlines()
+    lines = sphinx.ext.napoleon.NumpyDocstring(lines, app.config, app, "method", "", obj).lines()
+
+    with subtests.test("napoleon"):
+        # test that napoleon can parse things correctly
+        # especially the last parameter could fail to parse if there are not enough trailing newlines
+        for name in settings_class.model_fields:
+            assert f":param {name}:" in "\n".join(lines)
+
+    sphinx_autodoc_typehints.process_docstring(app, "method", "", obj, options=None, lines=lines)
+
+    with subtests.test("type"):  # no need to test all parameters
+        assert r":type field_bool: :sphinx_autodoc_typehints_type:`\:py\:class\:\`bool\`` (default: ``False``)" in lines
+    with subtests.test("rtype"):
+        assert (
+            r":rtype: :sphinx_autodoc_typehints_type:`\:py\:class\:\`\~contextlib.AbstractContextManager\`\\ \\\[\:py\:obj\:\`None\`\]`"
+            in lines
+        )

--- a/tests/test_settings.py
+++ b/tests/test_settings.py
@@ -146,16 +146,14 @@ def test_annotation_format(attr: str, expected: str) -> None:
     class Local: ...
 
     class S(Settings, exported_object_name="s", docstring_style="google"):
-        string: str
-        path: Path
-        local: Local
+        if attr == "string":
+            string: str
+        if attr == "path":
+            path: Path
+        if attr == "local":
+            local: Local
 
-    line_iter = iter((inspect.getdoc(S) or "").splitlines())
-    for line in line_iter:
-        if line == f".. attribute:: s.{attr}":
-            type_str = next(line_iter).strip().removeprefix(":type: ")
-            break
-    else:
-        raise AssertionError(f"Annotation for {attr} not found")
+    lines = (inspect.getdoc(S) or "").splitlines()
+    lines = lines[lines.index(f".. attribute:: s.{attr}") + 1 :]
 
-    assert type_str == expected
+    assert lines == [f"   :type: {expected}"]

--- a/tests/test_settings.py
+++ b/tests/test_settings.py
@@ -128,8 +128,9 @@ def test_override_docs(docstring_style: Literal["google", "numpy"], settings: Du
     for line in lines:
         if line.startswith(":param"):
             current_field_name, current_field = next(field_iter)
-            description = " " + current_field.description if current_field.description is not None else ""
-            assert line.startswith(f":param {current_field_name}: (default `{current_field.default!r}`){description}")
+            description = f" {current_field.description}" if current_field.description is not None else ""
+            # no default here, as the default is “leave this value alone”
+            assert line.startswith(f":param {current_field_name}:{description}")
         elif current_field is not None and len(line) > 0:
             assert current_field.annotation is not None
             assert line == f":type {current_field_name}: {current_field.annotation.__name__}"
@@ -199,7 +200,10 @@ def test_sphinx_autodoc_typehints(
     sphinx_autodoc_typehints.process_docstring(app, "method", "", obj, options=None, lines=lines)
 
     with subtests.test("type"):  # no need to test all parameters
-        assert r":type field_bool: :sphinx_autodoc_typehints_type:`\:py\:class\:\`bool\`` (default: ``False``)" in lines
+        assert (
+            r":type field_bool: :sphinx_autodoc_typehints_type:`\:py\:class\:\`bool\`` (default: ``<no change>``)"
+            in lines
+        )
     with subtests.test("rtype"):
         assert (
             r":rtype: :sphinx_autodoc_typehints_type:`\:py\:class\:\`\~contextlib.AbstractContextManager\`\\ \\\[\:py\:obj\:\`None\`\]`"

--- a/tests/test_settings.py
+++ b/tests/test_settings.py
@@ -50,7 +50,7 @@ def test_defaults_override() -> None:
         pytest.warns(RuntimeWarning, match="custom env_file location"),
     ):
 
-        class WarnSettings(Settings, exported_object_name="settings"):
+        class WarnSettings(Settings, exported_object_name="settings", docstring_style="google"):
             model_config = SettingsConfigDict(
                 validate_assignment=False, use_attribute_docstrings=False, env_file="mydotenv"
             )


### PR DESCRIPTION
Add annotations to `override` and a `"scverse"` docstring style which is “numpy but parameter types are only in the annotations and not in the docstring”. Scanpy enforces this style and doesn’t accept `param : type` syntax in the docstring.

This is a breaking change because it also removes the default for `docstring_style`, which I asked for in #16.

## alternatives

- instead of the `"scverse"` style, we could have an independent option for “no types in param docstrings” (e.g. `docstring_style="numpy", types_in_docstring=False`)
- do what I think is the best solution (but most work) and move all that logic out of the regular code and into a sphinx extension