### PR TITLE
remove seealso section from ExtensionNamespace

### DIFF
--- a/src/scverse_misc/_extensions.py
+++ b/src/scverse_misc/_extensions.py
@@ -29,9 +29,6 @@ class ExtensionNamespace(Protocol):
     Protocol's can't enforce that the `__init__` accepts the correct types. See
     `_check_namespace_signature` for that. This is mainly useful for static type
     checking with mypy and IDEs.
-
-    .. seealso::
-       :ref:`example-extension-namespaces`
     """
 
     def __init__(self, instance: object) -> None:


### PR DESCRIPTION
This protocol is meant to be re-rexported in downstream packages and included in their documentation (e.g. [anndata](https://anndata.scverse.org/en/stable/generated/anndata.types.ExtensionNamespace.html), which then can't resolve the link (e.g. in [mudata](https://mudata.readthedocs.io/latest/generated/mudata.ExtensionNamespace.html)) (and even if it could, linking to an example meant for developers makes no sense downstream).