### PR TITLE
tests: test multiple feature combinations

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -47,6 +47,5 @@ repos:
       - pydocstring-rs
       - pytest
       - sphinx
-      - sphinx-autodoc-typehints
       - sphinxcontrib-katex
       - types-PyYAML

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -68,18 +68,18 @@ envs.docs.scripts.open = "python -m webbrowser -t docs/_build/html/index.html"
 envs.docs.dependency-groups = [ "doc" ]
 envs.hatch-test.matrix = [
   # Test the lowest and highest supported Python versions with normal deps
-  { deps = [ "stable" ], python = [ "3.12", "3.13", "3.14" ], features = [ "full" ] },
+  { deps = [ "stable" ], python = [ "3.12", "3.13", "3.14" ], feature-set = [ "full" ] },
   # Test the newest supported Python version with different feature sets
-  { deps = [ "stable" ], python = [ "3.14" ], features = [ "min", "sphinx" ] },
+  { deps = [ "stable" ], python = [ "3.14" ], feature-set = [ "min", "sphinx" ] },
   # Test the newest supported Python version also with pre-release deps
-  { deps = [ "pre" ], python = [ "3.14" ], features = [ "full" ] },
+  { deps = [ "pre" ], python = [ "3.14" ], feature-set = [ "full" ] },
 ]
 # If the matrix variable `deps` is set to "pre",
 # set the environment variable `UV_PRERELEASE` to "allow".
 envs.hatch-test.overrides.matrix.deps.env-vars = [
   { value = "allow", key = "UV_PRERELEASE", if = [ "pre" ] },
 ]
-envs.hatch-test.overrides.matrix.features.features = [
+envs.hatch-test.overrides.matrix.feature-set.features = [
   # make sure the sphinx extension works without having all deps
   { value = "sphinx", if = [ "sphinx", "full" ] },
   { value = "datasets", if = [ "full" ] },

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -68,11 +68,11 @@ envs.docs.scripts.open = "python -m webbrowser -t docs/_build/html/index.html"
 envs.docs.dependency-groups = [ "doc" ]
 envs.hatch-test.matrix = [
   # Test the lowest and highest supported Python versions with normal deps
-  { deps = [ "stable" ], python = [ "3.12", "3.13", "3.14" ] },
+  { deps = [ "stable" ], python = [ "3.12", "3.13", "3.14" ], features = [ "full" ] },
   # Test the newest supported Python version with different feature sets
-  { deps = [ "stable" ], python = [ "3.14" ], features = [ "min", "sphinx", "full" ] },
+  { deps = [ "stable" ], python = [ "3.14" ], features = [ "min", "sphinx" ] },
   # Test the newest supported Python version also with pre-release deps
-  { deps = [ "pre" ], python = [ "3.14" ] },
+  { deps = [ "pre" ], python = [ "3.14" ], features = [ "full" ] },
 ]
 # If the matrix variable `deps` is set to "pre",
 # set the environment variable `UV_PRERELEASE` to "allow".

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -40,7 +40,7 @@ dev = [
   "pre-commit",
   "twine>=4.0.2",
 ]
-test = [ "coverage>=7.10", "numpy", "pytest", "sphinx", "sphinx-autodoc-typehints" ]
+test = [ "coverage>=7.10", "numpy", "pytest" ]
 doc = [
   "ipykernel",
   "ipython",
@@ -79,7 +79,7 @@ envs.hatch-test.matrix = [
 envs.hatch-test.overrides.matrix.deps.env-vars = [
   { value = "allow", key = "UV_PRERELEASE", if = [ "pre" ] },
 ]
-envs.hatch-test.overrides.matrix.deps.features = [
+envs.hatch-test.overrides.matrix.features.features = [
   # make sure the sphinx extension works without having all deps
   { value = "sphinx", if = [ "sphinx", "full" ] },
   { value = "datasets", if = [ "full" ] },

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -40,7 +40,7 @@ dev = [
   "pre-commit",
   "twine>=4.0.2",
 ]
-test = [ "coverage>=7.10", "numpy", "pytest" ]
+test = [ "coverage>=7.10", "pytest" ]
 doc = [
   "ipykernel",
   "ipython",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -22,12 +22,11 @@ classifiers = [
 ]
 dynamic = [ "version" ]
 dependencies = [
-  "anndata",
   # for debug logging (referenced from the issue template)
   "session-info2",
   "typing-extensions; python_version<'3.13'",
 ]
-optional-dependencies.datasets = [ "pooch", "pyyaml", "tqdm" ]
+optional-dependencies.datasets = [ "anndata", "pooch", "pyyaml", "tqdm" ]
 optional-dependencies.settings = [ "pydantic-settings", "python-dotenv" ]
 optional-dependencies.spatialdata = [ "spatialdata" ]
 optional-dependencies.sphinx = [ "pydocstring-rs>=0.1.13", "sphinx>=9" ]
@@ -41,14 +40,7 @@ dev = [
   "pre-commit",
   "twine>=4.0.2",
 ]
-test = [
-  "coverage>=7.10",
-  "numpy",
-  "pytest",
-  "scverse-misc[datasets,settings,sphinx]",
-  "sphinx",
-  "sphinx-autodoc-typehints"
-]
+test = [ "coverage>=7.10", "numpy", "pytest", "sphinx", "sphinx-autodoc-typehints" ]
 doc = [
   "ipykernel",
   "ipython",
@@ -77,6 +69,8 @@ envs.docs.dependency-groups = [ "doc" ]
 envs.hatch-test.matrix = [
   # Test the lowest and highest supported Python versions with normal deps
   { deps = [ "stable" ], python = [ "3.12", "3.13", "3.14" ] },
+  # Test the newest supported Python version with different feature sets
+  { deps = [ "stable" ], python = [ "3.14" ], features = [ "min", "sphinx", "full" ] },
   # Test the newest supported Python version also with pre-release deps
   { deps = [ "pre" ], python = [ "3.14" ] },
 ]
@@ -84,6 +78,13 @@ envs.hatch-test.matrix = [
 # set the environment variable `UV_PRERELEASE` to "allow".
 envs.hatch-test.overrides.matrix.deps.env-vars = [
   { value = "allow", key = "UV_PRERELEASE", if = [ "pre" ] },
+]
+envs.hatch-test.overrides.matrix.deps.features = [
+  # make sure the sphinx extension works without having all deps
+  { value = "sphinx", if = [ "sphinx", "full" ] },
+  { value = "datasets", if = [ "full" ] },
+  { value = "spatialdata", if = [ "full" ] },
+  { value = "settings", if = [ "full" ] },
 ]
 envs.hatch-test.dependency-groups = [ "dev", "test" ]
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,16 +1,18 @@
 from __future__ import annotations
 
 from collections.abc import Callable
+from importlib.util import find_spec
 from pathlib import Path
 from typing import TYPE_CHECKING, Literal, cast
 
 import pytest
-from sphinx.testing.util import SphinxTestApp
 
 if TYPE_CHECKING:
     from sphinx.ext.napoleon.docstring import GoogleDocstring, NumpyDocstring
+    from sphinx.testing.util import SphinxTestApp
 
-pytest_plugins = ["sphinx.testing.fixtures"]
+if find_spec("sphinx"):
+    pytest_plugins = ["sphinx.testing.fixtures"]
 
 
 @pytest.fixture(scope="session", params=["google", "numpy"])
@@ -36,12 +38,7 @@ def app(
     app = make_app(
         srcdir=tmp_path,
         confoverrides=dict(
-            extensions=[
-                "sphinx.ext.autodoc",
-                "scverse_misc.sphinx_ext",
-                "sphinx.ext.napoleon",
-                "sphinx_autodoc_typehints",
-            ],
+            extensions=["sphinx.ext.autodoc", "scverse_misc.sphinx_ext", "sphinx.ext.napoleon"],
             typehints_defaults="braces",
             napoleon_google_docstring=docstring_style == "google",
             napoleon_numpy_docstring=docstring_style == "numpy",

--- a/tests/deprecation_decorator/conftest.py
+++ b/tests/deprecation_decorator/conftest.py
@@ -19,9 +19,9 @@ def msg(request: pytest.FixtureRequest) -> str | None:
     return cast(str | None, request.param)
 
 
-@pytest.fixture()
+@pytest.fixture(scope="session")
 def docstring() -> str | None:
-    return None
+    return None  # gets overridden in `test_sphinx.py`
 
 
 @pytest.fixture

--- a/tests/deprecation_decorator/conftest.py
+++ b/tests/deprecation_decorator/conftest.py
@@ -1,0 +1,45 @@
+from __future__ import annotations
+
+from collections.abc import Callable
+from typing import cast
+
+import pytest
+
+from scverse_misc import Deprecation, deprecated
+
+
+@pytest.fixture(
+    params=[
+        pytest.param(None, id="no_message"),
+        pytest.param("Test message.", id="short_message"),
+        pytest.param("Test\nmessage.", id="long_message"),
+    ]
+)
+def msg(request: pytest.FixtureRequest) -> str | None:
+    return cast(str | None, request.param)
+
+
+@pytest.fixture()
+def docstring() -> str | None:
+    return None
+
+
+@pytest.fixture
+def func(docstring: str | None) -> Callable[..., int]:
+    def _func(
+        positional_only_no_default: int,
+        positional_only_default: int = 1337,
+        /,
+        positional_or_keyword_default: int = 42,
+        *,
+        keyword_only_default: float = 3.1415,
+    ) -> int:
+        return 42
+
+    _func.__doc__ = docstring
+    return _func
+
+
+@pytest.fixture
+def deprecated_func(msg: str | None, func: Callable[..., int]) -> Callable[..., int]:
+    return deprecated(Deprecation("foo", msg or ""))(func)

--- a/tests/deprecation_decorator/test_runtime.py
+++ b/tests/deprecation_decorator/test_runtime.py
@@ -1,0 +1,27 @@
+from __future__ import annotations
+
+from textwrap import indent
+from typing import TYPE_CHECKING
+
+import pytest
+
+from scverse_misc import Deprecation, deprecated_arg
+
+if TYPE_CHECKING:
+    from collections.abc import Callable
+
+
+def test_deprecation_decorator(deprecated_func: Callable[..., int], msg: str | None) -> None:
+    msg = indent(msg, "    ") if isinstance(msg, str) and "\n" in msg else (msg or "")
+    with pytest.warns(FutureWarning, match=rf"(?s)is deprecated.*{msg}"):
+        assert deprecated_func(1, 2, 3, keyword_only_default=4.0) == 42
+
+
+@pytest.mark.parametrize(
+    "arg",
+    ("positional_only_no_default", "positional_only_default", "positional_or_keyword_default", "keyword_only_default"),
+)
+def test_deprecated_arg_decorator(func: Callable[..., int], msg: str | None, arg: str) -> None:
+    deprecated_func = deprecated_arg(arg, Deprecation("2.718", msg or ""))(func)
+    with pytest.warns(FutureWarning, match=rf"{arg} is deprecated.*{msg or ''}"):
+        assert deprecated_func(1, 2, 3, keyword_only_default=4.0) == 42

--- a/tests/deprecation_decorator/test_sphinx.py
+++ b/tests/deprecation_decorator/test_sphinx.py
@@ -3,27 +3,17 @@ from __future__ import annotations
 import inspect
 import warnings
 from collections.abc import Callable
-from typing import TYPE_CHECKING, Literal, cast
+from typing import TYPE_CHECKING, Literal
 
 import pytest
-from sphinx.ext.napoleon import GoogleDocstring, NumpyDocstring  # type: ignore[attr-defined]
 
-from scverse_misc import Deprecation, deprecated, deprecated_arg, sphinx_ext
+pytest.importorskip("scverse_misc.sphinx_ext")
+from scverse_misc import Deprecation, deprecated_arg, sphinx_ext
 from scverse_misc.constants import ATTR_DEPRECATED, ATTR_DEPRECATED_ARG
 
 if TYPE_CHECKING:
     from sphinx.application import Sphinx
-
-
-@pytest.fixture(
-    params=[
-        pytest.param(None, id="no_message"),
-        pytest.param("Test message.", id="short_message"),
-        pytest.param("Test\nmessage.", id="long_message"),
-    ]
-)
-def msg(request: pytest.FixtureRequest) -> str | None:
-    return cast(str | None, request.param)
+    from sphinx.ext.napoleon import GoogleDocstring, NumpyDocstring  # type: ignore[attr-defined]
 
 
 @pytest.fixture(scope="session", params=["no_docstring", "short", "long_googlestyle", "long_numpystyle"])
@@ -69,33 +59,9 @@ def docstring(request: pytest.FixtureRequest, docstring_style: Literal["google",
             pytest.fail(f"Unknown docstring style {typ}")
 
 
-@pytest.fixture
-def func(msg: str | None, docstring: str | None) -> Callable[..., int]:
-    def _func(
-        positional_only_no_default: int,
-        positional_only_default: int = 1337,
-        /,
-        positional_or_keyword_default: int = 42,
-        *,
-        keyword_only_default: float = 3.1415,
-    ) -> int:
-        return 42
-
-    _func.__doc__ = docstring
-    return _func
-
-
-@pytest.fixture
-def deprecated_func(msg: str | None, func: Callable[..., int]) -> Callable[..., int]:
-    return deprecated(Deprecation("foo", msg or ""))(func)
-
-
 def test_deprecation_decorator(
     app: Sphinx, deprecated_func: Callable[..., int], docstring: str | None, msg: str | None
 ) -> None:
-    with pytest.warns(FutureWarning, match="deprecated"):
-        assert deprecated_func(1, 2) == 42
-
     lines = (inspect.getdoc(deprecated_func) or "").splitlines()
     sphinx_ext._process_deprecated_function(app, getattr(deprecated_func, ATTR_DEPRECATED), lines)
     offset = 0 if docstring is None else 2

--- a/tests/extension/test_sphinx.py
+++ b/tests/extension/test_sphinx.py
@@ -4,9 +4,9 @@ import inspect
 from typing import TYPE_CHECKING
 
 import pytest
-from sphinx.ext.autodoc import Options as AutodocOptions
 
 pytest.importorskip("scverse_misc.sphinx_ext")
+from sphinx.ext.autodoc import Options as AutodocOptions
 
 from scverse_misc import make_register_namespace_decorator
 from scverse_misc.sphinx_ext import _process_docstring

--- a/tests/extension/test_sphinx.py
+++ b/tests/extension/test_sphinx.py
@@ -3,7 +3,10 @@ from __future__ import annotations
 import inspect
 from typing import TYPE_CHECKING
 
+import pytest
 from sphinx.ext.autodoc import Options as AutodocOptions
+
+pytest.importorskip("scverse_misc.sphinx_ext")
 
 from scverse_misc import make_register_namespace_decorator
 from scverse_misc.sphinx_ext import _process_docstring

--- a/tests/settings/conftest.py
+++ b/tests/settings/conftest.py
@@ -1,3 +1,3 @@
 import pytest
 
-pytest.importorskip("scverse_misc.settings")
+pytest.importorskip("scverse_misc._settings")

--- a/tests/settings/conftest.py
+++ b/tests/settings/conftest.py
@@ -1,0 +1,3 @@
+import pytest
+
+pytest.importorskip("scverse_misc.settings")

--- a/tests/settings/test_sphinx.py
+++ b/tests/settings/test_sphinx.py
@@ -10,6 +10,8 @@ else:
     from typing_extensions import deprecated as stdlib_deprecated
 
 import pytest
+
+pytest.importorskip("scverse_misc.sphinx_ext")
 from pydantic import Field
 from pydantic.fields import FieldInfo
 from sphinx.application import Sphinx

--- a/tests/test_datasets.py
+++ b/tests/test_datasets.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 import sys
 import types
+from importlib.util import find_spec
 from pathlib import Path
 from typing import TYPE_CHECKING
 
@@ -119,6 +120,7 @@ def test_unknown_loader(registry: dict[str, DatasetEntry], tmp_path: Path) -> No
         fetch(registry["toy"], tmp_path)
 
 
+@pytest.mark.skipif(not find_spec("pooch"), reason="requires pooch")
 def test_download_drives_pooch(
     registry: dict[str, DatasetEntry], tmp_path: Path, monkeypatch: pytest.MonkeyPatch
 ) -> None:
@@ -153,6 +155,7 @@ def test_download_drives_pooch(
 
 
 # old anndata versions use the old arguments
+@pytest.mark.skipif(not find_spec("pooch"), reason="requires pooch")
 @pytest.mark.filterwarnings(
     r"ignore:The (decorator_name|docstring_style|exported_object_name)( class)? argument is deprecated:DeprecationWarning"
 )
@@ -165,6 +168,7 @@ def test_load_anndata_reads_h5ad(monkeypatch: pytest.MonkeyPatch, tmp_path: Path
     assert result == ("adata", "/cache/toy.h5ad", {"backed": "r"})
 
 
+@pytest.mark.skipif(not find_spec("pooch"), reason="requires pooch")
 def test_load_spatialdata_reads_zarr(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> None:
     fake_sd = types.ModuleType("spatialdata")
     fake_sd.read_zarr = lambda path, **kw: ("sdata", path)  # type: ignore[attr-defined]


### PR DESCRIPTION
- undo purposeless `anndata` mandatory dependency
- add test for `@deprecate` runtime behavior (`deprecate_arg` was tested in the same test as the

@timtreis why add the mandatory “anndata” extra? It does absolutely nothing without the `datasets` extra …

TODO:

- [x] figure out why the coverage goes down. It shouldn’t.