### PR TITLE
fix: allow adding `Settings` methods

### DIFF
--- a/src/scverse_misc/sphinx_ext/__init__.py
+++ b/src/scverse_misc/sphinx_ext/__init__.py
@@ -200,8 +200,6 @@ def _process_settings_method(app: Sphinx, method: MethodType, lines: list[str]) 
             _process_settings_method_override(app, method, lines)
         case "reset":
             _process_settings_method_reset(app, method, lines)
-        case _:
-            raise AssertionError
 
 
 def _process_settings_method_override(app: Sphinx, method: MethodType, lines: list[str]) -> None:
@@ -219,9 +217,9 @@ def _process_settings_method_override(app: Sphinx, method: MethodType, lines: li
 
 def _process_settings_method_reset(app: Sphinx, method: MethodType, lines: list[str]) -> None:
     settings = cast("Settings", method.__self__)
-    names_param = Parameter(
-        ["names"], type_annotation=f"typing.Literal[{', '.join(settings.model_fields.keys())}]", is_optional=True
-    )
+    annot = f"typing.Literal[{', '.join(settings.model_fields.keys())}]"
+    desc = "Names of settings to reset."
+    names_param = Parameter(["names"], type_annotation=annot, description=desc, is_optional=True)
     model = Docstring(summary=method.__doc__, sections=[Section(SectionKind.PARAMETERS, parameters=[names_param])])
     _emit_docstring(app, model, lines)
 


### PR DESCRIPTION
Also adds a description to the `reset` parameter, which fixes numpy style rendering