### PR TITLE
fix: avoid type stringification when others do it

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,11 @@ and this project adheres to [Semantic Versioning][].
 
 ## [Unreleased]
 
+### Fixed
+
+- The sphinx extension no longer adds parameter types to `override` and `reset` docstrings
+  if the users have `sphinx-autodoc-typehints` enabled or `autodoc_typehints = 'description' | 'both'` set.
+
 ## [0.1.0]
 
 ### Fixed

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -79,6 +79,9 @@ envs.hatch-test.matrix = [
 envs.hatch-test.overrides.matrix.deps.env-vars = [
   { value = "allow", key = "UV_PRERELEASE", if = [ "pre" ] },
 ]
+envs.hatch-test.overrides.matrix.feature-set.extra-dependencies = [
+  { value = "sphinx-autodoc-typehints", if = [ "sphinx", "full" ] },
+]
 envs.hatch-test.overrides.matrix.feature-set.features = [
   # make sure the sphinx extension works without having all deps
   { value = "sphinx", if = [ "sphinx", "full" ] },

--- a/src/scverse_misc/sphinx_ext/__init__.py
+++ b/src/scverse_misc/sphinx_ext/__init__.py
@@ -196,7 +196,9 @@ def _process_settings_object(settings: Settings, name: str, lines: list[str]) ->
 
 
 def _process_settings_method(app: Sphinx, method: MethodType, lines: list[str]) -> None:
-    add_annot = "sphinx_autodoc_typehints" not in app.extensions
+    sphinx_adds_type = getattr(app.config, "autodoc_typehints", None) in {"description", "both"}
+    ext_adds_type = "sphinx_autodoc_typehints" in app.extensions
+    add_annot = not sphinx_adds_type and not ext_adds_type
     match method.__name__:
         case "override":
             _process_settings_method_override(app, method, lines, add_annot=add_annot)

--- a/src/scverse_misc/sphinx_ext/__init__.py
+++ b/src/scverse_misc/sphinx_ext/__init__.py
@@ -196,17 +196,22 @@ def _process_settings_object(settings: Settings, name: str, lines: list[str]) ->
 
 
 def _process_settings_method(app: Sphinx, method: MethodType, lines: list[str]) -> None:
+    add_annot = "sphinx_autodoc_typehints" not in app.extensions
     match method.__name__:
         case "override":
-            _process_settings_method_override(app, method, lines)
+            _process_settings_method_override(app, method, lines, add_annot=add_annot)
         case "reset":
-            _process_settings_method_reset(app, method, lines)
+            _process_settings_method_reset(app, method, lines, add_annot=add_annot)
 
 
-def _process_settings_method_override(app: Sphinx, method: MethodType, lines: list[str]) -> None:
+def _process_settings_method_override(app: Sphinx, method: MethodType, lines: list[str], *, add_annot: bool) -> None:
     settings = cast("Settings", method.__self__)
     params = [
-        Parameter([fname], type_annotation=type_str(type(settings), field), description=field.description)
+        Parameter(
+            [fname],
+            type_annotation=type_str(type(settings), field) if add_annot else None,
+            description=field.description,
+        )
         for fname, field in type(settings).model_fields.items()
     ]
     model = Docstring(
@@ -216,9 +221,9 @@ def _process_settings_method_override(app: Sphinx, method: MethodType, lines: li
     _emit_docstring(app, model, lines)
 
 
-def _process_settings_method_reset(app: Sphinx, method: MethodType, lines: list[str]) -> None:
+def _process_settings_method_reset(app: Sphinx, method: MethodType, lines: list[str], *, add_annot: bool) -> None:
     settings = cast("Settings", method.__self__)
-    annot = f"typing.Literal[{', '.join(settings.model_fields.keys())}]"
+    annot = f"typing.Literal[{', '.join(settings.model_fields.keys())}]" if add_annot else None
     desc = "Names of settings to reset."
     names_param = Parameter(["names"], type_annotation=annot, description=desc, is_optional=True)
     model = Docstring(summary=method.__doc__, sections=[Section(SectionKind.PARAMETERS, parameters=[names_param])])

--- a/tests/settings/test_sphinx.py
+++ b/tests/settings/test_sphinx.py
@@ -2,7 +2,7 @@ from __future__ import annotations
 
 import inspect
 import sys
-from typing import Annotated
+from typing import Annotated, Literal
 
 if sys.version_info >= (3, 13):
     from warnings import deprecated as stdlib_deprecated
@@ -82,18 +82,23 @@ def test_override(subtests: pytest.Subtests, app: Sphinx, parser: type[GoogleDoc
     assert not list(field_iter)
 
 
-@pytest.mark.parametrize("enable_s_a_t", [True, False], ids=["s_a_t", "no_s_a_t"])
-def test_override_s_a_t(app: Sphinx, parser: type[GoogleDocstring | NumpyDocstring], enable_s_a_t: bool) -> None:
+@pytest.mark.parametrize("adds_types", ["s_a_t", "autodoc", None])
+def test_override_add_types(
+    app: Sphinx, parser: type[GoogleDocstring | NumpyDocstring], adds_types: Literal["s_a_t", "autodoc", None]
+) -> None:
     """Test that `:type <param>:` isn’t added (by us!) when `sphinx_autodoc_typehints` is enabled."""
-    if enable_s_a_t:
+    if adds_types == "s_a_t":
         app.setup_extension("sphinx_autodoc_typehints")
+    elif adds_types == "autodoc":
+        app.setup_extension("sphinx.ext.autodoc")
+        app.config.autodoc_typehints = "description"
     settings = DummySettings()
     lines = (inspect.getdoc(settings.override) or "").splitlines()
     _process_docstring(app, "method", "tests.settings.override", settings.override, AutodocOptions(), lines)
     lines = parser(lines).lines()
 
     assert ":param field_bool: Boolean field." in lines
-    assert (":type" not in "\n".join(lines)) == enable_s_a_t
+    assert (":type" in "\n".join(lines)) == (adds_types is None)
 
 
 @pytest.mark.parametrize(

--- a/tests/settings/test_sphinx.py
+++ b/tests/settings/test_sphinx.py
@@ -82,6 +82,20 @@ def test_override(subtests: pytest.Subtests, app: Sphinx, parser: type[GoogleDoc
     assert not list(field_iter)
 
 
+@pytest.mark.parametrize("enable_s_a_t", [True, False], ids=["s_a_t", "no_s_a_t"])
+def test_override_s_a_t(app: Sphinx, parser: type[GoogleDocstring | NumpyDocstring], enable_s_a_t: bool) -> None:
+    """Test that `:type <param>:` isn’t added (by us!) when `sphinx_autodoc_typehints` is enabled."""
+    if enable_s_a_t:
+        app.setup_extension("sphinx_autodoc_typehints")
+    settings = DummySettings()
+    lines = (inspect.getdoc(settings.override) or "").splitlines()
+    _process_docstring(app, "method", "tests.settings.override", settings.override, AutodocOptions(), lines)
+    lines = parser(lines).lines()
+
+    assert ":param field_bool: Boolean field." in lines
+    assert (":type" not in "\n".join(lines)) == enable_s_a_t
+
+
 @pytest.mark.parametrize(
     ("attr", "expected"),
     [


### PR DESCRIPTION
Which I’m pretty sure means “the `sphinx_autodoc_typehints` extension is enabled or the [`autodoc_typehints`](https://www.sphinx-doc.org/en/master/usage/extensions/autodoc.html#confval-autodoc_typehints) setting is set to `"description"` or `"both"`.

TODO: Should we start adding return types (i.e. a RETURNS section)? I think there’s added complexity with `napoleon_use_rtype` and `typehints_use_rtype` (at least Sphinx’ autodoc doesn’t allow to turn them off separately, so that’s simple)