### PR TITLE
sphinx ext: fix Settings.reset docs

### DIFF
--- a/src/scverse_misc/sphinx_ext/__init__.py
+++ b/src/scverse_misc/sphinx_ext/__init__.py
@@ -222,7 +222,9 @@ def _process_settings_method_reset(app: Sphinx, method: MethodType, lines: list[
     names_param = Parameter(
         ["names"], type_annotation=f"typing.Literal[{', '.join(settings.model_fields.keys())}]", is_optional=True
     )
-    model = Docstring(summary=method.__doc__, sections=[Section(SectionKind.PARAMETERS, parameters=[names_param])])
+
+    model = parse("\n".join(lines)).to_model()
+    model.sections = [Section(SectionKind.PARAMETERS, parameters=[names_param])]
     _emit_docstring(app, model, lines)
 
 


### PR DESCRIPTION
two issues:
- method.__doc__ had the indented docstring, which needs to be unindented, otherwise the description shows up as a blockquote
- pydocstring.Docstring expects a one-line summary for the summary parameter, the description goes into extended_summary

Easier to just parse the lines and replace the sections.