### PR TITLE
Sphinx extension: make _member_type work with module aliases

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,12 @@ and this project adheres to [Semantic Versioning][].
 [keep a changelog]: https://keepachangelog.com/
 [semantic versioning]: https://semver.org/spec/
 
+## [0.1.3]
+
+### Fixed
+
+- The sphinx extension now handles module aliases correctly.
+
 ## [0.1.2]
 
 ### Added
@@ -109,7 +115,8 @@ and this project adheres to [Semantic Versioning][].
 
 - Initial release
 
-[Unreleased]: https://github.com/scverse/scverse-misc/compare/v0.1.2...HEAD
+[Unreleased]: https://github.com/scverse/scverse-misc/compare/v0.1.3...HEAD
+[0.1.3]: https://github.com/scverse/scverse-misc/releases/tag/v0.1.3
 [0.1.2]: https://github.com/scverse/scverse-misc/releases/tag/v0.1.2
 [0.1.1]: https://github.com/scverse/scverse-misc/releases/tag/v0.1.1
 [0.1.0]: https://github.com/scverse/scverse-misc/releases/tag/v0.1.0

--- a/src/scverse_misc/sphinx_ext/__init__.py
+++ b/src/scverse_misc/sphinx_ext/__init__.py
@@ -3,10 +3,10 @@ from __future__ import annotations
 import re
 import sys
 import textwrap
+import traceback
 import warnings
 from importlib.metadata import version
 from pathlib import Path
-from textwrap import indent
 from types import MethodType
 from typing import TYPE_CHECKING, Any, Generic, Literal, cast, get_origin
 
@@ -16,10 +16,12 @@ else:
     from typing_extensions import deprecated as deprecated
 
 from jinja2.defaults import DEFAULT_FILTERS  # type: ignore[attr-defined]
-from jinja2.utils import import_string
 from pydocstring import Document, Parsed, Style, TextBlock, emit_google, emit_numpy, parse
 from pydocstring.model import Block, Docstring, Parameter, Return, Section, SectionKind
+from sphinx.ext.autodoc import Options as AutodocOptions
+from sphinx.ext.autodoc import import_object
 from sphinx.ext.napoleon import NumpyDocstring  # type: ignore[attr-defined]
+from sphinx.util import logging
 
 from .._deprecated import Deprecation, deprecated_arg
 from .._extensions import _NSInfo
@@ -39,12 +41,13 @@ if TYPE_CHECKING:
     from collections.abc import Generator, Iterable
 
     from sphinx.application import Sphinx
-    from sphinx.ext.autodoc import Options as AutodocOptions
     from sphinx.ext.autodoc import _AutodocObjType  # type: ignore[attr-defined]
     from sphinx.util.typing import ExtensionMetadata
 
 
 __all__ = ["setup"]
+
+_logger = logging.getLogger(__package__)
 
 
 def setup(app: Sphinx) -> ExtensionMetadata:  # noqa: D103
@@ -91,8 +94,14 @@ def _member_type(obj_path: str) -> Literal["method", "property", "attribute"]:
     E.g.: `.. auto{{ fullname | member_type }}::`
     """
     # https://jinja.palletsprojects.com/en/stable/api/#custom-filters
-    cls_path, member_name = obj_path.rsplit(".", 1)
-    cls = import_string(cls_path)
+    cls_path, cls_name, member_name = obj_path.rsplit(".", 2)
+    try:
+        cls = import_object(cls_path, [cls_name], "class")[-1]
+    except ImportError:
+        _logger.error(
+            f"Failed to import {cls_name} from {cls_path}; the following exception was rased: {traceback.format_exc()}"
+        )
+        return "attribute"
     member = getattr(cls, member_name, None)
     match member:
         case property():
@@ -189,7 +198,7 @@ def _process_deprecated_args(app: Sphinx, deprecations: list[deprecated_arg], li
             indentation = parsed.line_indent(par.range.start) + "    "
         docmsg = f".. version-deprecated:: {deprecation.msg.version_deprecated}"
         if len(deprecation.msg):
-            docmsg += f"\n{indent(deprecation.msg, '   ')}"
+            docmsg += f"\n{textwrap.indent(deprecation.msg, '   ')}"
 
         docmsg_lines = docmsg.splitlines()
         if len(docmsg_lines) > 1:
@@ -254,7 +263,7 @@ def _process_settings_object(settings: Settings, name: str, lines: list[str]) ->
         if deprecation_msg is not None:
             doc.append("")
             doc.append(f"   .. version-deprecated:: {deprecation_version}")
-            doc.append(indent(deprecation_msg, 6 * " "))
+            doc.append(textwrap.indent(deprecation_msg, 6 * " "))
 
         if field.description is not None:
             doc.append("")

--- a/src/scverse_misc/sphinx_ext/templates/autosummary/class.rst
+++ b/src/scverse_misc/sphinx_ext/templates/autosummary/class.rst
@@ -16,7 +16,7 @@
 
     .. autosummary::
 {% endif %}
-        ~{{ name }}.{{ item }}
+       ~{{ item }}
 {%- endfor %}
 {% endblock %}
 
@@ -28,7 +28,7 @@
 
     .. autosummary::
 {% endif %}
-        ~{{ name }}.{{ item }}
+       ~{{ item }}
 {% endfor %}
 {% endblock %}
 

--- a/tests/test_sphinx.py
+++ b/tests/test_sphinx.py
@@ -1,3 +1,4 @@
+import sys
 from functools import cache
 
 import pytest
@@ -32,11 +33,22 @@ class DummyCls:
         return 4.13
 
 
-def test_member_type() -> None:
+alias = sys.modules[__name__]
+
+
+@pytest.mark.parametrize(
+    ["attrname", "attrtype"],
+    (
+        ("attr", "attribute"),
+        ("func", "method"),
+        ("prop", "property"),
+        ("static", "method"),
+        ("klass", "method"),
+        ("cached", "method"),
+    ),
+)
+def test_member_type(attrname: str, attrtype: str) -> None:
     obj_path = f"{__name__}.DummyCls.{{}}"
-    assert _member_type(obj_path.format("attr")) == "attribute"
-    assert _member_type(obj_path.format("func")) == "method"
-    assert _member_type(obj_path.format("prop")) == "property"
-    assert _member_type(obj_path.format("static")) == "method"
-    assert _member_type(obj_path.format("klass")) == "method"
-    assert _member_type(obj_path.format("cached")) == "method"
+    alias_path = f"{__name__}.alias.DummyCls.{{}}"
+    assert _member_type(obj_path.format(attrname)) == attrtype
+    assert _member_type(alias_path.format(attrname)) == attrtype


### PR DESCRIPTION
The public API of a package often has aliases for modules defined in private submodules, which our _member_type could not handle before. Use Sphinx' import system instead of Jinja's so this works.

Also fix the class template to handle this case correctly.

I noticed this when merging the cookiecutter template update PR into mofaflex, so this probably affects a number of repos, so I would make a release when this is merged.