### PR TITLE
datasets: implement a fallback URL mechanism.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,12 @@ and this project adheres to [Semantic Versioning][].
 [keep a changelog]: https://keepachangelog.com/
 [semantic versioning]: https://semver.org/spec/
 
+## [0.1.4] (Unreleased)
+
+### Added
+
+- The `datasets` module can now download files from fallback URLs if a download from the primary URL fails.
+
 ## [0.1.3]
 
 ### Fixed
@@ -115,7 +121,7 @@ and this project adheres to [Semantic Versioning][].
 
 - Initial release
 
-[Unreleased]: https://github.com/scverse/scverse-misc/compare/v0.1.3...HEAD
+[0.1.4]: https://github.com/scverse/scverse-misc/releases/tag/v0.1.4
 [0.1.3]: https://github.com/scverse/scverse-misc/releases/tag/v0.1.3
 [0.1.2]: https://github.com/scverse/scverse-misc/releases/tag/v0.1.2
 [0.1.1]: https://github.com/scverse/scverse-misc/releases/tag/v0.1.1

--- a/src/scverse_misc/datasets/_fetcher.py
+++ b/src/scverse_misc/datasets/_fetcher.py
@@ -9,7 +9,6 @@ from __future__ import annotations
 
 import warnings
 from collections.abc import Callable
-from contextlib import suppress
 from dataclasses import replace
 from pathlib import Path
 from typing import TYPE_CHECKING, Any, Protocol, cast, overload
@@ -107,6 +106,7 @@ def fetch[T](
             urls={file.name: file.resolve_url(base_url)},
             retry_if_failed=retries,
         )
+        exceptions = []
         try:
             return pup.fetch(file.name, processor=processor, progressbar=True)
         except (OSError, ValueError) as e:
@@ -115,10 +115,13 @@ def fetch[T](
             warnings.warn(
                 f"Primary download for {file.name}, failed with {e!r}, retrying with fallback URLs.", stacklevel=3
             )
+            exceptions.append(e)
             for fallback in file.fallback_urls:
-                with suppress(OSError, ValueError):
+                try:
                     return download(replace(file, url=fallback, fallback_urls=None), dest=dest, processor=processor)
-            raise
+                except (OSError, ValueError) as e:
+                    exceptions.append(e)
+            raise ExceptionGroup(f"Could not download {file.name}", exceptions) from None
 
     if entry.type not in _LOADERS:
         raise KeyError(f"No loader registered for type {entry.type!r}. Available: {available_loaders()}")

--- a/src/scverse_misc/datasets/_fetcher.py
+++ b/src/scverse_misc/datasets/_fetcher.py
@@ -9,6 +9,7 @@ from __future__ import annotations
 
 import warnings
 from collections.abc import Callable
+from contextlib import suppress
 from dataclasses import replace
 from pathlib import Path
 from typing import TYPE_CHECKING, Any, Protocol, cast, overload
@@ -94,7 +95,7 @@ def fetch[T](
     """
     target = Path(cache_dir) / entry.type
 
-    def download(file: FileEntry, /, dest: Path | None = None, processor: Processor | None = None) -> str:  # type: ignore[return]
+    def download(file: FileEntry, /, dest: Path | None = None, processor: Processor | None = None) -> str:
         import pooch
 
         out = dest or target
@@ -115,7 +116,9 @@ def fetch[T](
                 f"Primary download for {file.name}, failed with {e!r}, retrying with fallback URLs.", stacklevel=3
             )
             for fallback in file.fallback_urls:
-                return download(replace(file, url=fallback, fallback_urls=None), dest=dest, processor=processor)
+                with suppress(OSError, ValueError):
+                    return download(replace(file, url=fallback, fallback_urls=None), dest=dest, processor=processor)
+            raise
 
     if entry.type not in _LOADERS:
         raise KeyError(f"No loader registered for type {entry.type!r}. Available: {available_loaders()}")

--- a/src/scverse_misc/datasets/_fetcher.py
+++ b/src/scverse_misc/datasets/_fetcher.py
@@ -11,18 +11,16 @@ from collections.abc import Callable
 from pathlib import Path
 from typing import TYPE_CHECKING, Any, Protocol, cast, overload
 
+import pooch
+
 if TYPE_CHECKING:
+    from pooch.typing import Processor
+
     from ._registry import DatasetEntry, FileEntry
 
     if TYPE_CHECKING:  # sphinx tries to import the above TYPE_CHECKING block
         from anndata import AnnData
-        from pooch.typing import Processor
         from spatialdata import SpatialData
-    else:
-        from typing import TypeAliasType
-
-        # TypeAliasType.__module__ is readonly, so we have to be a bit creative.
-        Processor = eval('A("Processor", object)', globals=dict(__name__="pooch.typing", A=TypeAliasType))
 
 
 __all__ = ["register_loader", "available_loaders", "fetch", "Loader", "DownloadCB"]
@@ -82,13 +80,18 @@ def fetch[T](
 ) -> T:  # type: ignore[type-var]
     """Download (if needed) and load ``entry``, dispatching to the loader registered for ``entry.type``.
 
-    Files are cached under ``cache_dir / entry.type``. ``kwargs`` are passed to the loader.
+    Files are cached under ``cache_dir / entry.type``.
+
+    Args:
+        entry: File to download.
+        cache_dir: Directory to download to.
+        base_url: The base URL.
+        retries: Number of attempts before failure.
+        **kwargs: Passed to the loader.
     """
     target = Path(cache_dir) / entry.type
 
     def download(file: FileEntry, /, dest: Path | None = None, processor: Processor | None = None) -> str:
-        import pooch
-
         out = dest or target
         out.mkdir(parents=True, exist_ok=True)
         pup = pooch.create(
@@ -121,7 +124,6 @@ def _load_spatialdata(entry: DatasetEntry, target: Path, download: DownloadCB, /
     the registry key) without colliding with other spatialdata datasets cached under the same ``target``.
     Needs the ``spatialdata`` extra.
     """
-    import pooch
     import spatialdata as sd
 
     dest = target / entry.name

--- a/src/scverse_misc/datasets/_fetcher.py
+++ b/src/scverse_misc/datasets/_fetcher.py
@@ -7,11 +7,11 @@ retries, and archive processors). ``anndata`` and ``spatialdata`` loaders ship b
 
 from __future__ import annotations
 
+import warnings
 from collections.abc import Callable
+from dataclasses import replace
 from pathlib import Path
 from typing import TYPE_CHECKING, Any, Protocol, cast, overload
-
-import pooch
 
 if TYPE_CHECKING:
     from pooch.typing import Processor
@@ -88,10 +88,15 @@ def fetch[T](
         base_url: The base URL.
         retries: Number of attempts before failure.
         **kwargs: Passed to the loader.
+
+    Returns:
+        The absolte path of the downloaded file.
     """
     target = Path(cache_dir) / entry.type
 
-    def download(file: FileEntry, /, dest: Path | None = None, processor: Processor | None = None) -> str:
+    def download(file: FileEntry, /, dest: Path | None = None, processor: Processor | None = None) -> str:  # type: ignore[return]
+        import pooch
+
         out = dest or target
         out.mkdir(parents=True, exist_ok=True)
         pup = pooch.create(
@@ -101,7 +106,16 @@ def fetch[T](
             urls={file.name: file.resolve_url(base_url)},
             retry_if_failed=retries,
         )
-        return pup.fetch(file.name, processor=processor, progressbar=True)
+        try:
+            return pup.fetch(file.name, processor=processor, progressbar=True)
+        except (OSError, ValueError) as e:
+            if not file.fallback_urls:
+                raise
+            warnings.warn(
+                f"Primary download for {file.name}, failed with {e!r}, retrying with fallback URLs.", stacklevel=3
+            )
+            for fallback in file.fallback_urls:
+                return download(replace(file, url=fallback, fallback_urls=None), dest=dest, processor=processor)
 
     if entry.type not in _LOADERS:
         raise KeyError(f"No loader registered for type {entry.type!r}. Available: {available_loaders()}")
@@ -124,6 +138,7 @@ def _load_spatialdata(entry: DatasetEntry, target: Path, download: DownloadCB, /
     the registry key) without colliding with other spatialdata datasets cached under the same ``target``.
     Needs the ``spatialdata`` extra.
     """
+    import pooch
     import spatialdata as sd
 
     dest = target / entry.name

--- a/src/scverse_misc/datasets/_fetcher.py
+++ b/src/scverse_misc/datasets/_fetcher.py
@@ -113,7 +113,7 @@ def fetch[T](
             if not file.fallback_urls:
                 raise
             warnings.warn(
-                f"Primary download for {file.name}, failed with {e!r}, retrying with fallback URLs.", stacklevel=3
+                f"Primary download for {file.name} failed with {e!r}, retrying with fallback URLs.", stacklevel=3
             )
             exceptions.append(e)
             for fallback in file.fallback_urls:

--- a/src/scverse_misc/datasets/_registry.py
+++ b/src/scverse_misc/datasets/_registry.py
@@ -19,16 +19,11 @@ __all__ = ["FileEntry", "DatasetEntry", "parse_registry"]
 class FileEntry:
     """A single downloadable file belonging to a dataset.
 
-    Parameters
-    ----------
-    name
-        File name as it should appear on disk (e.g. ``"cells.zip"``).
-    url
-        Full download URL (e.g. a Zenodo file URL). Takes precedence over ``s3_key``.
-    s3_key
-        Key relative to the registry's ``base_url``. Used when ``url`` is unset.
-    sha256
-        Expected SHA-256 hash. If set, downloads are verified against it.
+    Args:
+        name: File name as it should appear on disk (e.g. ``"cells.zip"``).
+        url: Full download URL (e.g. a Zenodo file URL). Takes precedence over ``s3_key``.
+        s3_key: Key relative to the registry's ``base_url``. Used when ``url`` is unset.
+        sha256: Expected SHA-256 hash. If set, downloads are verified against it.
     """
 
     name: str
@@ -47,16 +42,19 @@ class FileEntry:
 
 @dataclass(frozen=True, slots=True)
 class DatasetEntry:
-    """A named dataset made up of one or more files.
-
-    ``metadata`` holds everything in the YAML row other than ``type`` and ``files``
-    (e.g. ``shape``, ``library_id``, ``doc_header``); the core does not interpret it.
-    """
+    """A named dataset made up of one or more files."""
 
     name: str
+    """File name on disk."""
+
     type: str
+    """Entry type, e.g. `"anndata`"."""
+
     files: tuple[FileEntry, ...]
+    """The files for this dataset."""
+
     metadata: Mapping[str, Any] = field(default_factory=dict)
+    """Everything in the YAML other than ``type`` and ``files``."""
 
     def file(self, *, name: str | None = None, suffix: str | None = None) -> FileEntry:
         """Return the file matching ``name`` (exact) or ``suffix`` (endswith). Raises unless exactly one matches."""
@@ -93,6 +91,27 @@ def parse_registry(path: PathLike[str] | str) -> tuple[str | None, dict[str, Dat
     The YAML has a top-level ``base_url`` (or ``s3_base_url``) and a ``datasets`` mapping of
     ``name -> {type, files: [{name, url?/s3_key?, sha256?}], ...}``. Any keys other than ``type``
     and ``files`` are collected into the entry's ``metadata``.
+
+    Examples:
+        .. code-block:: yaml
+
+           base_url: https://example.com/data
+
+           datasets:
+
+             example1:
+               type: anndata
+               files:
+                 - name: example1.h5ad
+                   s3_key: ABCDEFGH.h5ad
+                   sha256: 86126c1a3c163ea20abb14c1a9711aaff34e6c492ef6dd86298bbaf18cc3f5f3
+
+              example2:
+                type: anndata
+                files:
+                  - name: example2.h5ad
+                    url: https://example.com/otherdata/DEFGHI.h5ad
+                    sha256: e7b358fef2b6da115b7ee3ab4c7fc55fd80e210bba427902e4afc9118992747c
     """
     with open(path) as f:
         config = yaml.safe_load(f) or {}

--- a/src/scverse_misc/datasets/_registry.py
+++ b/src/scverse_misc/datasets/_registry.py
@@ -17,19 +17,22 @@ __all__ = ["FileEntry", "DatasetEntry", "parse_registry"]
 
 @dataclass(frozen=True, slots=True)
 class FileEntry:
-    """A single downloadable file belonging to a dataset.
-
-    Args:
-        name: File name as it should appear on disk (e.g. ``"cells.zip"``).
-        url: Full download URL (e.g. a Zenodo file URL). Takes precedence over ``s3_key``.
-        s3_key: Key relative to the registry's ``base_url``. Used when ``url`` is unset.
-        sha256: Expected SHA-256 hash. If set, downloads are verified against it.
-    """
+    """A single downloadable file belonging to a dataset."""
 
     name: str
+    """File name as it should appear on disk (e.g. ``"cells.zip"``)."""
+
     url: str | None = None
+    """Full download URL (e.g. a Zenodo file URL). Takes precedence over ``s3_key``."""
+
     s3_key: str | None = None
+    """Key relative to the registry's ``base_url``. Used when ``url`` is unset."""
+
     sha256: str | None = None
+    """Expected SHA-256 hash. If set, downloads are verified against it."""
+
+    fallback_urls: list[str] | None = None
+    """List of fallback download URLs to use in case the primary URL or the S3 bucket fail."""
 
     def resolve_url(self, base_url: str | None = None) -> str:
         """Resolve the download URL: the explicit ``url`` if set, else ``base_url/s3_key``."""
@@ -89,7 +92,7 @@ def parse_registry(path: PathLike[str] | str) -> tuple[str | None, dict[str, Dat
     """Parse a YAML registry into ``(base_url, {name: DatasetEntry})``.
 
     The YAML has a top-level ``base_url`` (or ``s3_base_url``) and a ``datasets`` mapping of
-    ``name -> {type, files: [{name, url?/s3_key?, sha256?}], ...}``. Any keys other than ``type``
+    ``name -> {type, files: [{name, url?/s3_key?, sha256?, fallback_urls?}], ...}``. Any keys other than ``type``
     and ``files`` are collected into the entry's ``metadata``.
 
     Examples:
@@ -105,6 +108,9 @@ def parse_registry(path: PathLike[str] | str) -> tuple[str | None, dict[str, Dat
                  - name: example1.h5ad
                    s3_key: ABCDEFGH.h5ad
                    sha256: 86126c1a3c163ea20abb14c1a9711aaff34e6c492ef6dd86298bbaf18cc3f5f3
+                  fallback_urls:
+                    - https://example.org/fallbackdata/ABCDEFGH.h5ad
+                    - https://example.net/data/ABCDEFGH.h5ad
 
               example2:
                 type: anndata

--- a/src/scverse_misc/datasets/_registry.py
+++ b/src/scverse_misc/datasets/_registry.py
@@ -96,21 +96,21 @@ def parse_registry(path: PathLike[str] | str) -> tuple[str | None, dict[str, Dat
     and ``files`` are collected into the entry's ``metadata``.
 
     Examples:
-        .. code-block:: yaml
+        ..  code-block:: yaml
 
-           base_url: https://example.com/data
+            base_url: https://example.com/data
 
-           datasets:
+            datasets:
 
-             example1:
-               type: anndata
-               files:
-                 - name: example1.h5ad
-                   s3_key: ABCDEFGH.h5ad
-                   sha256: 86126c1a3c163ea20abb14c1a9711aaff34e6c492ef6dd86298bbaf18cc3f5f3
-                   fallback_urls:
-                     - https://example.org/fallbackdata/ABCDEFGH.h5ad
-                     - https://example.net/data/ABCDEFGH.h5ad
+              example1:
+                type: anndata
+                files:
+                  - name: example1.h5ad
+                    s3_key: ABCDEFGH.h5ad
+                    sha256: 86126c1a3c163ea20abb14c1a9711aaff34e6c492ef6dd86298bbaf18cc3f5f3
+                    fallback_urls:
+                      - https://example.org/fallbackdata/ABCDEFGH.h5ad
+                      - https://example.net/data/ABCDEFGH.h5ad
 
               example2:
                 type: anndata

--- a/src/scverse_misc/datasets/_registry.py
+++ b/src/scverse_misc/datasets/_registry.py
@@ -108,9 +108,9 @@ def parse_registry(path: PathLike[str] | str) -> tuple[str | None, dict[str, Dat
                  - name: example1.h5ad
                    s3_key: ABCDEFGH.h5ad
                    sha256: 86126c1a3c163ea20abb14c1a9711aaff34e6c492ef6dd86298bbaf18cc3f5f3
-                    fallback_urls:
-                      - https://example.org/fallbackdata/ABCDEFGH.h5ad
-                      - https://example.net/data/ABCDEFGH.h5ad
+                   fallback_urls:
+                     - https://example.org/fallbackdata/ABCDEFGH.h5ad
+                     - https://example.net/data/ABCDEFGH.h5ad
 
               example2:
                 type: anndata

--- a/src/scverse_misc/datasets/_registry.py
+++ b/src/scverse_misc/datasets/_registry.py
@@ -108,9 +108,9 @@ def parse_registry(path: PathLike[str] | str) -> tuple[str | None, dict[str, Dat
                  - name: example1.h5ad
                    s3_key: ABCDEFGH.h5ad
                    sha256: 86126c1a3c163ea20abb14c1a9711aaff34e6c492ef6dd86298bbaf18cc3f5f3
-                  fallback_urls:
-                    - https://example.org/fallbackdata/ABCDEFGH.h5ad
-                    - https://example.net/data/ABCDEFGH.h5ad
+                    fallback_urls:
+                      - https://example.org/fallbackdata/ABCDEFGH.h5ad
+                      - https://example.net/data/ABCDEFGH.h5ad
 
               example2:
                 type: anndata

--- a/tests/test_datasets.py
+++ b/tests/test_datasets.py
@@ -2,13 +2,14 @@ from __future__ import annotations
 
 import sys
 import types
-from importlib.util import find_spec
 from pathlib import Path
 from typing import TYPE_CHECKING
 
 import pytest
 
 try:
+    import pooch
+
     from scverse_misc.datasets import (
         DatasetEntry,
         FileEntry,
@@ -26,7 +27,7 @@ if TYPE_CHECKING:
 
 
 _YAML = """\
-base_url: https://example.org/data/
+base_url: https://example.invalid/data/
 datasets:
   toy:
     type: dummy
@@ -35,6 +36,8 @@ datasets:
       - name: toy.h5ad
         s3_key: toy.h5ad
         sha256: abc123
+        fallback_urls:
+          - https://fallback.invalid/data/toy.h5ad
   remote:
     type: dummy
     files:
@@ -48,7 +51,7 @@ def registry(tmp_path: Path) -> dict[str, DatasetEntry]:
     p = tmp_path / "datasets.yaml"
     p.write_text(_YAML)
     base_url, datasets = parse_registry(p)
-    assert base_url == "https://example.org/data/"
+    assert base_url == "https://example.invalid/data/"
     return datasets
 
 
@@ -123,7 +126,6 @@ def test_unknown_loader(registry: dict[str, DatasetEntry], tmp_path: Path) -> No
         fetch(registry["toy"], tmp_path)
 
 
-@pytest.mark.skipif(not find_spec("pooch"), reason="requires pooch")
 def test_download_drives_pooch(
     registry: dict[str, DatasetEntry], tmp_path: Path, monkeypatch: pytest.MonkeyPatch
 ) -> None:
@@ -138,8 +140,6 @@ def test_download_drives_pooch(
     def fake_create(**kw: object) -> FakePup:
         calls.update(kw)
         return FakePup()
-
-    import pooch
 
     monkeypatch.setattr(pooch, "create", fake_create)
 
@@ -157,8 +157,31 @@ def test_download_drives_pooch(
     assert calls["fetched"] == "toy.h5ad"
 
 
+def test_fallback_urls(registry: dict[str, DatasetEntry], tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    tried = False
+
+    def fake_fetch(self: pooch.Pooch, name: str, *args: object, **kwargs: object) -> str:
+        nonlocal tried
+        if not tried:
+            tried = True
+            raise OSError()
+        else:
+            return name
+
+    monkeypatch.setattr(pooch.Pooch, "fetch", fake_fetch)
+
+    @register_loader("dummy")
+    def _load(entry: DatasetEntry, target: Path, download: DownloadCB, /, **kw: object) -> str:
+        return download(entry.files[0])
+
+    with pytest.warns(UserWarning, match="retrying with fallback URLs"):
+        try:
+            assert fetch(registry["toy"], tmp_path, base_url="https://test.invalid") == registry["toy"].files[0].name
+        finally:
+            _fetcher._LOADERS.pop("dummy", None)
+
+
 # old anndata versions use the old arguments
-@pytest.mark.skipif(not find_spec("pooch"), reason="requires pooch")
 @pytest.mark.filterwarnings(
     r"ignore:The (decorator_name|docstring_style|exported_object_name)( class)? argument is deprecated:DeprecationWarning"
 )
@@ -171,7 +194,6 @@ def test_load_anndata_reads_h5ad(monkeypatch: pytest.MonkeyPatch, tmp_path: Path
     assert result == ("adata", "/cache/toy.h5ad", {"backed": "r"})
 
 
-@pytest.mark.skipif(not find_spec("pooch"), reason="requires pooch")
 def test_load_spatialdata_reads_zarr(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> None:
     fake_sd = types.ModuleType("spatialdata")
     fake_sd.read_zarr = lambda path, **kw: ("sdata", path)  # type: ignore[attr-defined]

--- a/tests/test_datasets.py
+++ b/tests/test_datasets.py
@@ -38,6 +38,7 @@ datasets:
         sha256: abc123
         fallback_urls:
           - https://fallback.invalid/data/toy.h5ad
+          - https://fallback2.invalid/data/toy.h5ad
   remote:
     type: dummy
     files:
@@ -158,12 +159,12 @@ def test_download_drives_pooch(
 
 
 def test_fallback_urls(registry: dict[str, DatasetEntry], tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
-    tried = False
+    tried = 0
 
     def fake_fetch(self: pooch.Pooch, name: str, *args: object, **kwargs: object) -> str:
         nonlocal tried
-        if not tried:
-            tried = True
+        if tried < 2:
+            tried += 1
             raise OSError()
         else:
             return name


### PR DESCRIPTION
This is apparently being used in the wild with workarounds, so we should provide it here.