### PR TITLE
deprecated_arg: automatically skip the calling package

### DIFF
--- a/src/scverse_misc/_deprecated/__init__.py
+++ b/src/scverse_misc/_deprecated/__init__.py
@@ -5,6 +5,7 @@ from functools import wraps
 from typing import TYPE_CHECKING, LiteralString, Protocol, cast
 from warnings import warn
 
+from .._utils import get_caller_package_file_prefixes, get_package_file_prefixes
 from ..constants import ATTR_DEPRECATED_ARG
 
 if TYPE_CHECKING:
@@ -48,6 +49,9 @@ class CallableWithDeprecatedArg[**P, R](Protocol):
     def __call__(*args: P.args, **kwargs: P.kwargs) -> R: ...
 
 
+_helper_packages = ("legacy_api_wrap",)
+
+
 class deprecated_arg:
     """Decorator to indicate that a function argument is deprecated.
 
@@ -79,6 +83,9 @@ class deprecated_arg:
         self.stacklevel = stacklevel
 
     def __call__[**P, R](self, func: Callable[P, R]) -> CallableWithDeprecatedArg[P, R]:
+        skipfiles = list(get_caller_package_file_prefixes())
+        for helper in _helper_packages:
+            skipfiles.extend(get_package_file_prefixes(helper))  # TODO: use comprehension unpacking in Python 3.15
         warnmsg = f"The argument {self.arg} is deprecated and will be removed in the future."
         if len(self.msg):
             warnmsg += f" {self.msg}"
@@ -92,11 +99,18 @@ class deprecated_arg:
                 param.kind in (inspect.Parameter.KEYWORD_ONLY, inspect.Parameter.POSITIONAL_OR_KEYWORD)
                 and self.arg in kwargs
             ):
-                warn(warnmsg, category=self.category, stacklevel=self.stacklevel + 1)
+                warn(
+                    warnmsg, category=self.category, stacklevel=self.stacklevel + 1, skip_file_prefixes=tuple(skipfiles)
+                )
             else:
                 bound = sig.bind(*args, **kwargs)
                 if self.arg in bound.arguments and bound.arguments[self.arg] != param.default:
-                    warn(warnmsg, category=self.category, stacklevel=self.stacklevel + 1)
+                    warn(
+                        warnmsg,
+                        category=self.category,
+                        stacklevel=self.stacklevel + 1,
+                        skip_file_prefixes=tuple(skipfiles),
+                    )
 
             return func(*args, **kwargs)
 

--- a/src/scverse_misc/_utils.py
+++ b/src/scverse_misc/_utils.py
@@ -55,7 +55,7 @@ def get_packagename(cls: type | str) -> str:
     return package_name
 
 
-def get_caller_package(stacklevel: int = 0) -> str:
+def get_caller_package(stacklevel: int = 0) -> str | None:
     frame = inspect.currentframe()
     if TYPE_CHECKING:
         assert frame is not None
@@ -65,7 +65,7 @@ def get_caller_package(stacklevel: int = 0) -> str:
         else:
             break
     module = inspect.getmodule(frame)
-    return get_packagename(module.__name__) if module is not None else ""
+    return get_packagename(module.__name__) if module is not None else None
 
 
 def get_package_file_prefixes(packagename: str) -> tuple[str, ...]:
@@ -83,7 +83,8 @@ def get_package_file_prefixes(packagename: str) -> tuple[str, ...]:
 
 
 def get_caller_package_file_prefixes() -> tuple[str, ...]:
-    return get_package_file_prefixes(get_caller_package(1))
+    caller_pkg = get_caller_package(1)
+    return get_package_file_prefixes(caller_pkg) if caller_pkg is not None else ()
 
 
 def type_str(cls: type, field: FieldInfo) -> str:

--- a/src/scverse_misc/_utils.py
+++ b/src/scverse_misc/_utils.py
@@ -5,6 +5,7 @@ import inspect
 import sys
 from collections.abc import Callable, Mapping
 from functools import WRAPPER_ASSIGNMENTS
+from pathlib import Path
 from types import FunctionType, GenericAlias
 from typing import TYPE_CHECKING, ParamSpec, TypedDict, TypeVar, TypeVarTuple, Unpack, cast
 
@@ -52,6 +53,37 @@ def get_packagename(cls: type | str) -> str:
     if dotidx > -1:
         package_name = package_name[:dotidx]
     return package_name
+
+
+def get_caller_package(stacklevel: int = 0) -> str:
+    frame = inspect.currentframe()
+    if TYPE_CHECKING:
+        assert frame is not None
+    for _ in range(stacklevel + 2):
+        if (back := frame.f_back) is not None:
+            frame = back
+        else:
+            break
+    module = inspect.getmodule(frame)
+    return get_packagename(module.__name__) if module is not None else ""
+
+
+def get_package_file_prefixes(packagename: str) -> tuple[str, ...]:
+    try:
+        module = sys.modules[packagename]
+    except KeyError:
+        return ()
+    if file := module.__file__:
+        return (str(Path(file).parent),)
+    else:  # namespace package
+        if (spec := module.__spec__) is not None and (locs := spec.submodule_search_locations) is not None:
+            return tuple(locs)
+        else:
+            return ()
+
+
+def get_caller_package_file_prefixes() -> tuple[str, ...]:
+    return get_package_file_prefixes(get_caller_package(1))
 
 
 def type_str(cls: type, field: FieldInfo) -> str:

--- a/tests/deprecation_decorator/test_runtime.py
+++ b/tests/deprecation_decorator/test_runtime.py
@@ -5,7 +5,7 @@ from typing import TYPE_CHECKING
 
 import pytest
 
-from scverse_misc import Deprecation, deprecated_arg
+from scverse_misc import Deprecation, _utils, deprecated_arg
 
 if TYPE_CHECKING:
     from collections.abc import Callable
@@ -21,7 +21,18 @@ def test_deprecation_decorator(deprecated_func: Callable[..., int], msg: str | N
     "arg",
     ("positional_only_no_default", "positional_only_default", "positional_or_keyword_default", "keyword_only_default"),
 )
-def test_deprecated_arg_decorator(func: Callable[..., int], msg: str | None, arg: str) -> None:
+@pytest.mark.parametrize("skip_package", (True, False))
+def test_deprecated_arg_decorator(
+    monkeypatch: pytest.MonkeyPatch, func: Callable[..., int], msg: str | None, arg: str, skip_package: bool
+) -> None:
+    if not skip_package:
+        monkeypatch.setattr(_utils, "get_package_file_prefixes", lambda x: ())
     deprecated_func = deprecated_arg(arg, Deprecation("2.718", msg or ""))(func)
-    with pytest.warns(FutureWarning, match=rf"{arg} is deprecated.*{msg or ''}"):
+    with pytest.warns(FutureWarning, match=rf"{arg} is deprecated.*{msg or ''}") as warned:
         assert deprecated_func(1, 2, 3, keyword_only_default=4.0) == 42
+
+    warning = warned[0]
+    if skip_package:
+        assert warning.filename != __file__
+    else:
+        assert warning.filename == __file__


### PR DESCRIPTION
Add the package where the decorator is called `to skip_file_prefixes`, so all warnings appear to come from client code. Additionally, a list of known helper packages is maintained and added to the skiplist.

This only affects `deprecated_arg`, since `deprecated` uses `warnings.deprecated` which does not support `skip_file_prefixes`.

Closes #80.