### PR TITLE
Add an arg_alias decorator.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,13 @@ and this project adheres to [Semantic Versioning][].
 [keep a changelog]: https://keepachangelog.com/
 [semantic versioning]: https://semver.org/spec/
 
+## [0.1.5] (Unreleased)
+
+### Added
+
+- An `arg_alias` decorator that simplifies handling of function arguments taking on one of a fixed set of values, where
+  each value may have multiple aliases (e.g. the `axis` argument of many scverse functions).
+
 ## [0.1.4]
 
 ### Added
@@ -121,6 +128,7 @@ and this project adheres to [Semantic Versioning][].
 
 - Initial release
 
+[0.1.5]: https://github.com/scverse/scverse-misc/releases/tag/v0.1.5
 [0.1.4]: https://github.com/scverse/scverse-misc/releases/tag/v0.1.4
 [0.1.3]: https://github.com/scverse/scverse-misc/releases/tag/v0.1.3
 [0.1.2]: https://github.com/scverse/scverse-misc/releases/tag/v0.1.2

--- a/docs/api.md
+++ b/docs/api.md
@@ -57,6 +57,15 @@ Types used by the former:
 
 *Examples:* {ref}`example-settings-class`
 
+(arg_alias)=
+## Argument value aliasing
+```{eval-rst}
+.. autosummary::
+   :toctree: generated
+
+    arg_alias
+```
+
 (datasets)=
 ## Datasets (`scverse_misc.datasets`)
 

--- a/src/scverse_misc/__init__.py
+++ b/src/scverse_misc/__init__.py
@@ -1,9 +1,17 @@
 from contextlib import suppress
 
+from ._arg_alias import arg_alias
 from ._deprecated import Deprecation, deprecated, deprecated_arg
 from ._extensions import ExtensionNamespace, make_register_namespace_decorator
 
-__all__ = ["ExtensionNamespace", "make_register_namespace_decorator", "deprecated", "deprecated_arg", "Deprecation"]
+__all__ = [
+    "ExtensionNamespace",
+    "make_register_namespace_decorator",
+    "deprecated",
+    "deprecated_arg",
+    "Deprecation",
+    "arg_alias",
+]
 
 with suppress(ImportError):
     from ._settings import Settings  # noqa: F401

--- a/src/scverse_misc/_arg_alias.py
+++ b/src/scverse_misc/_arg_alias.py
@@ -1,7 +1,7 @@
 from collections.abc import Callable
 from functools import wraps
 from inspect import signature
-from typing import Any, Literal, Union, get_args, get_origin, get_type_hints
+from typing import Literal, Union, get_args, get_origin, get_type_hints
 
 
 def arg_alias[**P, R](argname: str) -> Callable[[Callable[P, R]], Callable[P, R]]:
@@ -49,7 +49,7 @@ def arg_alias[**P, R](argname: str) -> Callable[[Callable[P, R]], Callable[P, R]
         else:
             raise TypeError(f"Type hint for argument '{argname}' must be 'Union' or 'Literal', found '{hint}'.")
 
-        replacements: dict[Any, Any] = {}
+        replacements: dict[object, object] = {}
         values = set()
 
         for aliasset in sets:

--- a/src/scverse_misc/_arg_alias.py
+++ b/src/scverse_misc/_arg_alias.py
@@ -1,0 +1,83 @@
+from collections.abc import Callable
+from functools import wraps
+from inspect import signature
+from typing import Any, Literal, Union, get_args, get_origin, get_type_hints
+
+
+def arg_alias[**P, R](argname: str) -> Callable[[Callable[P, R]], Callable[P, R]]:
+    """Decorator to specify aliases for function arguments that accept a fixed set of values.
+
+    If a function argument accepts a fixed set of values that partitions into multiple equivalence classes
+    (i.e. several values are aliased to the same behavior), this decorator converts each equivalence class
+    into its chosen canonical representation before passing it on to the function. This eliminates the need
+    for the function to perform validation and conversion itself, the function can be certain that it always
+    gets the canonical representation.
+
+    The rules are encoded in the type hint for the aliased argument. If there is only a single set of aliases,
+    the type hint must be a :obj:`~typing.Literal` with the canonical representation as first argument followed
+    by its aliases. If there are multiple sets of aliases, that is multiple semantically different values that
+    the function accepts, the type hint must be a :obj:`~typing.Union` of :obj:`~typing.Literal` s, where each
+    :obj:`~typing.Literal` follows the same rules as above: The canonical representation is the first argument
+    followed by its aliases.
+
+    Args:
+        argname: The name of the argument to alias.
+
+    Examples:
+        >>> @axis_arg("axis")
+        ... def foo(x: int, axis: Literal[0, "obs"]):
+        ...     return axis
+        ...
+        ...
+        ... assert foo(42, 0) == foo(42, "obs") == 0
+
+        >>> @axis_arg("axis")
+        ... def foo(x: float, axis: Literal[0, "obs"] | Literal[1, "var", "vars"]):
+        ...     return axis
+        ...
+        ...
+        ... assert foo(42, 0) == foo(42, "obs") == 1
+        ... assert foo(42, 1) == foo(42, "var") == foo(42, "vars") == 1
+    """
+
+    def wrapper(func: Callable[P, R]) -> Callable[P, R]:
+        hint = get_type_hints(func)[argname]
+        if get_origin(hint) is Literal:
+            sets = (hint,)
+        elif get_origin(hint) is Union:
+            sets = get_args(hint)
+        else:
+            raise TypeError(f"Type hint for argument '{argname}' must be 'Union' or 'Literal', found '{hint}'.")
+
+        replacements: dict[Any, Any] = {}
+        values = set()
+
+        for aliasset in sets:
+            if get_origin(aliasset) is not Literal:
+                raise TypeError(
+                    f"All type hints specifying aliases for argument '{argname}' must be 'Literal', found '{aliasset}'."
+                )
+            value, *aliases = get_args(aliasset)
+            values.add(value)
+            replacements.update((alias, value) for alias in aliases)
+
+        sig = signature(func)
+
+        @wraps(func)
+        def wrapped(*args: P.args, **kwargs: P.kwargs) -> R:
+            bound = sig.bind(*args, **kwargs)
+            bound.apply_defaults()
+
+            argval = bound.arguments[argname]
+            try:
+                bound.arguments[argname] = replacements[argval]
+            except KeyError:
+                if argval not in values:
+                    raise ValueError(
+                        f"Argument '{argname}' must be one of {tuple(values) + tuple(replacements.keys())}, got '{argval}'."
+                    ) from None
+            return func(*bound.args, **bound.kwargs)
+
+        return wrapped
+
+    return wrapper

--- a/tests/test_arg_alias.py
+++ b/tests/test_arg_alias.py
@@ -6,6 +6,7 @@ from scverse_misc import arg_alias
 
 
 def test_arg_alias() -> None:
+    @arg_alias("axis_union_string")
     @arg_alias("axis_union")
     @arg_alias("axis")
     def func(
@@ -13,21 +14,26 @@ def test_arg_alias() -> None:
         axis: Literal[0, "obs", "samples"],
         y: float = 2,
         axis_union: Literal[0, "obs"] | Literal[1, "var", "features"] = "var",
-    ) -> tuple[float, float]:
+        axis_union_string: "Literal[0, 'obs'] | Literal[1, 'var', 'vars']" = "vars",
+    ) -> tuple[int, int, int]:
         assert axis == 0
         assert axis_union in (0, 1)
+        assert axis_union_string in (0, 1)
 
-        return x * axis, y * axis_union
+        return axis, axis_union, axis_union_string
 
-    assert func(42, 0) == (0, 2)
-    assert func(42, "obs") == (0, 2)
-    assert func(42, "samples", 3) == (0, 3)
-    assert func(42, 0, axis_union="obs") == (0, 0)
-    assert func(42, 0, axis_union="features") == (0, 2)
-    assert func(42, 0, axis_union=0) == (0, 0)
+    assert func(42, 0) == (0, 1, 1)
+    assert func(42, "obs") == (0, 1, 1)
+    assert func(42, "samples", 3) == (0, 1, 1)
+    assert func(42, 0, axis_union="obs", axis_union_string="obs") == (0, 0, 0)
+    assert func(42, 0, axis_union="features", axis_union_string="vars") == (0, 1, 1)
+    assert func(42, 0, axis_union=0, axis_union_string=0) == (0, 0, 0)
 
     with pytest.raises(ValueError, match="must be one of "):
         func(42, "obs", axis_union="vars")  # type: ignore[arg-type]
+
+    with pytest.raises(ValueError, match="must be one of "):
+        func(42, "obs", axis_union_string="features")  # type: ignore[arg-type]
 
 
 def test_arg_alias_raises() -> None:

--- a/tests/test_arg_alias.py
+++ b/tests/test_arg_alias.py
@@ -9,7 +9,6 @@ from scverse_misc import arg_alias
 
 @pytest.mark.parametrize("stringify", [True, False], ids=["stringify", "no_stringify"])
 def test_arg_alias(stringify: bool) -> None:
-    @arg_alias("axis_union_string")
     @arg_alias("axis_union")
     @arg_alias("axis")
     def func(
@@ -17,13 +16,11 @@ def test_arg_alias(stringify: bool) -> None:
         axis: Literal[0, "obs", "samples"],
         y: float = 2,
         axis_union: Literal[0, "obs"] | Literal[1, "var", "features"] = "var",
-        axis_union_string: "Literal[0, 'obs'] | Literal[1, 'var', 'vars']" = "vars",
-    ) -> tuple[int, int, int]:
+    ) -> tuple[int, int]:
         assert axis == 0
         assert axis_union in (0, 1)
-        assert axis_union_string in (0, 1)
 
-        return axis, axis_union, axis_union_string
+        return axis, axis_union
 
     if stringify:
         ns: dict[str, object] = {}
@@ -32,18 +29,15 @@ def test_arg_alias(stringify: bool) -> None:
             func = ns["func"]
     assert isinstance(func.__annotations__["return"], str) == stringify
 
-    assert func(42, 0) == (0, 1, 1)
-    assert func(42, "obs") == (0, 1, 1)
-    assert func(42, "samples", 3) == (0, 1, 1)
-    assert func(42, 0, axis_union="obs", axis_union_string="obs") == (0, 0, 0)
-    assert func(42, 0, axis_union="features", axis_union_string="vars") == (0, 1, 1)
-    assert func(42, 0, axis_union=0, axis_union_string=0) == (0, 0, 0)
+    assert func(42, 0) == (0, 1)
+    assert func(42, "obs") == (0, 1)
+    assert func(42, "samples", 3) == (0, 1)
+    assert func(42, 0, axis_union="obs") == (0, 0)
+    assert func(42, 0, axis_union="features") == (0, 1)
+    assert func(42, 0, axis_union=0) == (0, 0)
 
     with pytest.raises(ValueError, match="must be one of "):
         func(42, "obs", axis_union="vars")  # type: ignore[arg-type]
-
-    with pytest.raises(ValueError, match="must be one of "):
-        func(42, "obs", axis_union_string="features")  # type: ignore[arg-type]
 
 
 def test_arg_alias_raises() -> None:

--- a/tests/test_arg_alias.py
+++ b/tests/test_arg_alias.py
@@ -1,0 +1,44 @@
+from typing import Literal
+
+import pytest
+
+from scverse_misc import arg_alias
+
+
+def test_arg_alias() -> None:
+    @arg_alias("axis_union")
+    @arg_alias("axis")
+    def func(
+        x: float,
+        axis: Literal[0, "obs", "samples"],
+        y: float = 2,
+        axis_union: Literal[0, "obs"] | Literal[1, "var", "features"] = "var",
+    ) -> tuple[float, float]:
+        assert axis == 0
+        assert axis_union in (0, 1)
+
+        return x * axis, y * axis_union
+
+    assert func(42, 0) == (0, 2)
+    assert func(42, "obs") == (0, 2)
+    assert func(42, "samples", 3) == (0, 3)
+    assert func(42, 0, axis_union="obs") == (0, 0)
+    assert func(42, 0, axis_union="features") == (0, 2)
+    assert func(42, 0, axis_union=0) == (0, 0)
+
+    with pytest.raises(ValueError, match="must be one of "):
+        func(42, "obs", axis_union="vars")  # type: ignore[arg-type]
+
+
+def test_arg_alias_raises() -> None:
+    with pytest.raises(TypeError, match="must be 'Union' or 'Literal'"):
+
+        @arg_alias("axis")
+        def func(axis: int) -> None:
+            pass
+
+    with pytest.raises(TypeError, match="must be 'Literal'"):
+
+        @arg_alias("axis")
+        def func(axis: Literal[0, "obs"] | int) -> None:
+            pass

--- a/tests/test_arg_alias.py
+++ b/tests/test_arg_alias.py
@@ -1,11 +1,14 @@
-from typing import Literal
+from inspect import getsource
+from textwrap import dedent
+from typing import TYPE_CHECKING, Literal
 
 import pytest
 
 from scverse_misc import arg_alias
 
 
-def test_arg_alias() -> None:
+@pytest.mark.parametrize("stringify", [True, False], ids=["stringify", "no_stringify"])
+def test_arg_alias(stringify: bool) -> None:
     @arg_alias("axis_union_string")
     @arg_alias("axis_union")
     @arg_alias("axis")
@@ -21,6 +24,13 @@ def test_arg_alias() -> None:
         assert axis_union_string in (0, 1)
 
         return axis, axis_union, axis_union_string
+
+    if stringify:
+        ns: dict[str, object] = {}
+        exec(f"from __future__ import annotations\n{dedent(getsource(func))}", globals(), ns)
+        if not TYPE_CHECKING:  # shhh
+            func = ns["func"]
+    assert isinstance(func.__annotations__["return"], str) == stringify
 
     assert func(42, 0) == (0, 1, 1)
     assert func(42, "obs") == (0, 1, 1)


### PR DESCRIPTION
Many scverse functions accept an axis argument that can be one of `0`, `"obs"`, `1`, and `"var"`, where `"obs"` is an alias for `0` and `"var"` is an alias for `1`. The function then usually performs some conversion and checking internally and proceeds with one canonical representation (usually `0` and `1`). This decorator generalizes this concept to arbitrary sets of values and aliases.

The rules are encoded in the type hint for the aliased argument. If there is only a single set of aliases, the type hint must be a `Literal` with the canonical representation as first argument followed by its aliases. If there are multiple sets of aliases, that is multiple semantically different values that the function accepts, as in the axis example above, the type hint must be a `Union` of `Literal` s, where each `Literal` follows the same rules as above: The canonical representation is the first argument followed by its aliases.